### PR TITLE
Moved from dedicated docker image to shared docker image

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,7 +29,7 @@ jobs:
     name: Test against pony-odbc test image
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/redvers/pony-odbc:latest
+      image: ghcr.io/redvers/pony-dependency-builder:latest
     services:
       postgres:
         image: postgres:14.5


### PR DESCRIPTION
Instead of generating a docker image containing all of the dependencies for each library / application, we're going to make one with all the dependencies.