### PR TITLE
Converted SQLInteger input/output to varchar(32)

### DIFF
--- a/pony-odbc/sql_integer.pony
+++ b/pony-odbc/sql_integer.pony
@@ -5,42 +5,25 @@ use "attributes"
 use "instrumentation"
 
 class SQLInteger
-  var v: CBoxedI32 = CBoxedI32
+  var v: CBoxedArray = CBoxedArray.>alloc(32)
   var is_null: Bool = false
   var err: SQLReturn val = SQLSuccess
-  new create(a: I32 = 0) => v.value = a
+  new create(a: I32 = 0) =>
+    v.write(a.string())
 
   fun ref bind_parameter(h: ODBCHandleStmt tag, col: U16): SQLReturn val => SQLSuccess
     var desc: SQLDescribeParamOut = SQLDescribeParamOut(col)
-    _verify_parameter(h, desc)
-    Debug.out(desc.debug())
-//    if (not _verify_parameter(h, desc)) then
-//      return err
-//    end
-    err
     if (not _bind_parameter(h, desc)) then
       return err
     end
     err
 
   fun ref _bind_parameter(h: ODBCHandleStmt tag, desc: SQLDescribeParamOut): Bool =>
-    err = ODBCStmtFFI.bind_parameter_i32(h, desc, v)
+    err = ODBCStmtFFI.bind_parameter_varchar(h, desc, v)
     is_success()
 
-  fun ref _verify_parameter(h: ODBCHandleStmt tag, desc: SQLDescribeParamOut): Bool =>
-    err = ODBCStmtFFI.describe_param(h, desc)
-    if (not is_success()) then
-      return false
-    end
-    match desc.data_type_ptr.value
-      // Apparently, mariadb insists on calling this a string - wut?
-    | 4  => return true // _bind_parameter(h, desc)
-    else
-      err = PonyDriverError
-      return false
-    end
-
-  fun native(): I32 => v.value
+  fun read(): I32 ? =>
+    v.string().i32()?
 
   fun is_success(): Bool =>
     match err
@@ -51,37 +34,18 @@ class SQLInteger
 
   fun ref bind_column(h: ODBCHandleStmt tag, col: U16, colname: String val): SQLReturn val => SQLSuccess
     var desc: SQLDescribeColOut = SQLDescribeColOut(col)
-    if (not _verify_column(h, desc, colname)) then
-      return err
-    end
-    err
     if (not _bind_column(h, desc)) then
       return err
     end
     err
 
-  fun ref _verify_column(h: ODBCHandleStmt tag, desc: SQLDescribeColOut, colname: String val): Bool =>
-    err = ODBCStmtFFI.describe_column(h, desc, colname)
-    if (not is_success()) then
-      return false
-    end
-
-    /* List of possible Integer types
-     *  4   SQLInteger
-     */
-    match desc.datatype_ptr.value
-    | 4  => return true
-    else
-      err = PonyDriverError
-      return false
-    end
-
   fun ref _bind_column(h: ODBCHandleStmt tag, desc: SQLDescribeColOut): Bool =>
-    err = ODBCStmtFFI.bind_column_i32(h, desc, v)
+    err = ODBCStmtFFI.bind_column_varchar(h, desc, v)
     is_success()
     true
 
-
+  fun ref write(a: I32) =>
+    v.write(a.string())
 
 
 

--- a/pony-odbc/tests/integer.pony
+++ b/pony-odbc/tests/integer.pony
@@ -41,7 +41,6 @@ class \nodoc\ iso _TestInteger is UnitTest
 
 
     var stmta: ODBCSth = ODBCSth(dbc, consume pcmp)
-
     h.assert_is[SQLReturn val](SQLSuccess, stmta.err)
     h.assert_true(stmta.prepare())
     show_error(stmta)
@@ -70,4 +69,3 @@ class \nodoc\ iso _TestInteger is UnitTest
       end
       true
     end
-

--- a/pony-odbc/tests/integer_model.pony
+++ b/pony-odbc/tests/integer_model.pony
@@ -30,24 +30,30 @@ class \nodoc\ iso _TestIntegerModel is ODBCQueryModel
     if (not is_success()) then return err end
     err
 
-  fun ref execute[A: Any val](h: ODBCHandleStmt tag, i: A): SQLReturn val =>
+  fun ref execute[A: Any val](h: ODBCHandleStmt tag, i: A): SQLReturn val => SQLSuccess
     match i
-    | let x: I32 => pin.integera.v.value = x
+    | let int: I32 =>
+      pin.integera.write(int)
+      SQLSuccess
     else
-      err = PonyDriverError
+      PonyDriverError
     end
-    err
 
-  fun ref bind_columns(h: ODBCHandleStmt tag): SQLReturn val =>
+
+  fun ref bind_columns(h: ODBCHandleStmt tag): SQLReturn val => SQLSuccess
     err = pout.integer.bind_column(h, 1, "i")
     err
 
-  fun ref fetch(h: ODBCHandleStmt tag): (SQLReturn val, _PCMResultI) =>
+  fun ref fetch(h: ODBCHandleStmt tag): (SQLReturn val, _PCMResultI) => (SQLSuccess, _PCMResultI)
     err = ODBCStmtFFI.fetch(h)
     if (not is_success()) then return (err, result) end
 
-    result.integer = pout.integer.native()
-    (err, result)
+    try
+      result.integer = pout.integer.read()?
+      (err, result)
+    else
+      (PonyDriverError, result)
+    end
 
   fun is_success(): Bool =>
     match err


### PR DESCRIPTION
As Mariadb states that all the numeric types we've come across thus far have parameter types of varchar(255), for consistency we're going to use these as input/output types.