### PR TITLE
Added string text to PonyDriverError.

### DIFF
--- a/pony-odbc/env/odbc_env.pony
+++ b/pony-odbc/env/odbc_env.pony
@@ -17,18 +17,19 @@ primitive \nodoc\ ODBCEnvFFI
     """
     ODBCEnvFFI.sql_alloc_handle()
 
-  fun set_odbc2(h: ODBCHandleEnv tag): SQLReturn =>
+  fun set_odbc2(h: ODBCHandleEnv tag): SQLReturn val =>
     """
     Sets the Environment to version ODBC2.  I should probably remove this
     since I've not implemented any of those functionsi (yet).
     """
-    match @SQLSetEnvAttr(NullablePointer[ODBCHandleEnv tag](h), SQLAttrOdbcVersion(), SQLAttrOvOdbc2(), SQLIsInteger())
+    var rv: I16 = @SQLSetEnvAttr(NullablePointer[ODBCHandleEnv tag](h), SQLAttrOdbcVersion(), SQLAttrOvOdbc2(), SQLIsInteger())
+    match rv
     | 0 => return SQLSuccess
-    | 1 => return SQLSuccessWithInfo.create_penv(h)
-    | -1 => return SQLError.create_penv(h)
+    | 1 => return recover val SQLSuccessWithInfo.create_penv(h) end
+    | -1 => return recover val SQLError.create_penv(h) end
     | -2 => return SQLInvalidHandle
     else
-      PonyDriverError
+      recover val PonyDriverError("ODBCEnvFFI.set_odbc2() got invalid return code: " + rv.string()) end
     end
 
   fun set_odbc3(h: ODBCHandleEnv tag): SQLReturn val =>
@@ -36,24 +37,26 @@ primitive \nodoc\ ODBCEnvFFI
     Sets the Environment to version ODBC3.  You should always call
     this, since version 3 is the only one implemented thus far.
     """
-    match @SQLSetEnvAttr(NullablePointer[ODBCHandleEnv tag](h), SQLAttrOdbcVersion(), SQLAttrOvOdbc3(), SQLIsInteger())
+    var rv: I16 = @SQLSetEnvAttr(NullablePointer[ODBCHandleEnv tag](h), SQLAttrOdbcVersion(), SQLAttrOvOdbc3(), SQLIsInteger())
+    match rv
     | 0 => return SQLSuccess
     | 1 => return recover val SQLSuccessWithInfo.create_penv(h) end
     | -1 => return recover val SQLError.create_penv(h) end
     | -2 => return SQLInvalidHandle
     else
-      PonyDriverError
+      recover val PonyDriverError("ODBCEnvFFI.set_odbc3() got invalid return code: " + rv.string()) end
     end
 
   fun sql_alloc_handle(): (SQLReturn val, ODBCHandleEnv tag) =>
     var rv: ODBCHandleEnv tag = ODBCHandleEnv
-    match @SQLAllocHandle(1, Pointer[None], addressof rv)
+    var rvv: I16 = @SQLAllocHandle(1, Pointer[None], addressof rv)
+    match rvv
     | 0 => return (SQLSuccess, rv)
     | 1 => return (recover val SQLSuccessWithInfo.create_penv(rv) end, rv)
     | -1 => return (recover val SQLError.create_penv(rv) end, rv)
     | -2 => return (SQLInvalidHandle, rv)
     else
-      (PonyDriverError, rv)
+      (recover val PonyDriverError("ODBCEnvFFI.set_odbc2() got invalid return code: " + rvv.string()) end, rv)
     end
 
   fun free(h: ODBCHandleEnv tag) => @SQLFreeHandle(1, NullablePointer[ODBCHandleEnv tag](h))

--- a/pony-odbc/instrumentation/pony_driver_error.pony
+++ b/pony-odbc/instrumentation/pony_driver_error.pony
@@ -1,2 +1,7 @@
-primitive PonyDriverError
+class PonyDriverError
+  var errorstr: String val
+
+  new create(str: String val) =>
+    errorstr = str
+
   fun string(): String val => "PonyDriverError"

--- a/pony-odbc/odbc_query_model.pony
+++ b/pony-odbc/odbc_query_model.pony
@@ -76,7 +76,7 @@ trait ODBCResultOut
 class ODBCResultOutNull is ODBCResultOut
 class ODBCQueryModelNull is ODBCQueryModel
   fun sql(): (String val | SQLReturn val) => ""
-  fun ref bind_params(h: ODBCHandleStmt tag): SQLReturn val => PonyDriverError
-  fun ref bind_columns(h: ODBCHandleStmt tag): SQLReturn val => PonyDriverError
-  fun ref fetch(h: ODBCHandleStmt tag): (SQLReturn val, ODBCResultOut) => (PonyDriverError, ODBCResultOutNull)
-  fun ref execute[A: Any val](h: ODBCHandleStmt tag, i: A): SQLReturn val => PonyDriverError
+  fun ref bind_params(h: ODBCHandleStmt tag): SQLReturn val => recover val PonyDriverError("ODBCQueryModelNull.bind_params shouldn't be called" ) end
+  fun ref bind_columns(h: ODBCHandleStmt tag): SQLReturn val => recover val PonyDriverError("ODBCQueryModelNull.bind_columns shouldn't be called") end
+  fun ref fetch(h: ODBCHandleStmt tag): (SQLReturn val, ODBCResultOut) => (recover val PonyDriverError("ODBCQueryModelNull.fetch shouldn't be called") end, ODBCResultOutNull)
+  fun ref execute[A: Any val](h: ODBCHandleStmt tag, i: A): SQLReturn val => recover val PonyDriverError("ODBCQueryModelNull.execute shouldn't be called") end

--- a/pony-odbc/sql_varchar.pony
+++ b/pony-odbc/sql_varchar.pony
@@ -94,7 +94,8 @@ class SQLVarchar
      *  -4  SQLLongVarBinary
      */
 
-    match desc.data_type_ptr.value
+    var dt: I16 = desc.data_type_ptr.value
+    match dt
     | 1  => true
     | 12 => true
     | -1 => true
@@ -102,7 +103,7 @@ class SQLVarchar
     | -3 => true
     | -4 => true
     else
-      err = PonyDriverError
+      err = recover val PonyDriverError("SQLVarchar._verify_parameter: Wanted [1,12,-1,-2,-3,-4], got: " + dt.string()) end
       return false
     end
 
@@ -135,7 +136,8 @@ class SQLVarchar
      *  -3  SQLVarBinary
      *  -4  SQLLongVarBinary
      */
-    match desc.datatype_ptr.value
+    var dt: I16 = desc.datatype_ptr.value
+    match dt
     | 1  => v.alloc(desc.colsize_ptr.value.usize()); return true
     | 12 => v.alloc(desc.colsize_ptr.value.usize()); return true
     | -1 => v.alloc(desc.colsize_ptr.value.usize()); return true
@@ -143,7 +145,7 @@ class SQLVarchar
     | -3 => v.alloc(desc.colsize_ptr.value.usize()); return true
     | -4 => v.alloc(desc.colsize_ptr.value.usize()); return true
     else
-      err = PonyDriverError
+      err = recover val PonyDriverError("SQLVarchar._verify_column: Wanted [1,12,-1,-2,-3,-4], got: " + dt.string()) end
       return false
     end
 

--- a/pony-odbc/tests/integer_model.pony
+++ b/pony-odbc/tests/integer_model.pony
@@ -36,7 +36,7 @@ class \nodoc\ iso _TestIntegerModel is ODBCQueryModel
       pin.integera.write(int)
       SQLSuccess
     else
-      PonyDriverError
+      recover val PonyDriverError("Wrong type provided to _TestIntegerModel.execute()") end
     end
 
 
@@ -52,7 +52,7 @@ class \nodoc\ iso _TestIntegerModel is ODBCQueryModel
       result.integer = pout.integer.read()?
       (err, result)
     else
-      (PonyDriverError, result)
+      (recover val PonyDriverError("_TestIntegerModel.fetch() did not return an I32") end, result)
     end
 
   fun is_success(): Bool =>


### PR DESCRIPTION
When your application received a PonyDriverError you had to go through the code line by line to find the source.

Adding a (mandatory) string to its definition will result in easier bugfixes.