### PR TITLE
Broke out backend of types to SQLType trait

### DIFF
--- a/pony-odbc/c_boxed_array.pony
+++ b/pony-odbc/c_boxed_array.pony
@@ -18,11 +18,6 @@ class \nodoc\ CBoxedArray
   var alloc_size: USize = 0
   var written_size: CBoxedI64 = CBoxedI64
 
-  fun ref init(str: String val): Bool =>
-    if (not alloc(str.size() + 1)) then return false end
-    write(str)
-
-
   fun ref alloc(size: USize): Bool =>
     if (not ptr.is_null()) then return false end
     ptr = @pony_alloc(@pony_ctx(), size)
@@ -48,6 +43,16 @@ class \nodoc\ CBoxedArray
     reset()
     @memcpy(ptr, str.cpointer(), str.size())
     written_size.value = str.size().i64()
+    true
+
+  fun ref write_array(arr: Array[U8] val): Bool =>
+    if (ptr.is_null()) then return false end
+    if (arr.size() > alloc_size) then
+      return false
+    end
+    reset()
+    @memcpy(ptr, arr.cpointer(), arr.size())
+    written_size.value = arr.size().i64()
     true
 
   fun array(): Array[U8] iso^ =>

--- a/pony-odbc/odbc_dbc.pony
+++ b/pony-odbc/odbc_dbc.pony
@@ -59,7 +59,7 @@ class ODBCDbc
       _valid = false ; return false
     end
 
-  fun ref set_error_text(sqlerr: SQLError val) =>
+  fun \nodoc\ ref set_error_text(sqlerr: SQLError val) =>
     errtext =
       "ODBCDbc API Error:\n" +
       _call_location.file() + ":" + _call_location.line().string() + ": " +

--- a/pony-odbc/sql_big_int.pony
+++ b/pony-odbc/sql_big_int.pony
@@ -1,0 +1,42 @@
+use "debug"
+use "stmt"
+
+class SQLBigInteger is SQLType
+  """
+  The internal class which represents an Integer (I64)
+  """
+  var _v: CBoxedArray = CBoxedArray
+  var _err: SQLReturn val = SQLSuccess
+
+  new create() => _v.alloc(22)
+
+  fun \nodoc\ ref get_boxed_array(): CBoxedArray => _v
+  fun \nodoc\ ref set_boxed_array(v': CBoxedArray) => _v = v'
+
+  fun \nodoc\ ref get_err(): SQLReturn val => _err
+  fun \nodoc\ ref set_err(err': SQLReturn val) => _err = err'
+
+  fun ref write(i64: I64): Bool =>
+    """
+    Write an I64 to this buffer as a string. The string will fit
+    as we defined the buffer to be characters on initialization.
+
+    Will return true if written and verification succeeds.
+
+    Will return false if the string is too long for the buffer or
+    the readback doesn't match for some other reason.
+    """
+    _write(i64.string())
+
+  fun ref read(): I64 ? =>
+    """
+    Read the value of the buffer and convert it into an I64.
+    
+    This function is partial just in case the string version
+    that comes from the database is not within the I32 range.
+
+    NOTE: SQLite does not enforce type limits, so if you use
+    that specific ODBC driver, this is something that must be
+    verified.
+    """
+    _v.string().i64()?

--- a/pony-odbc/sql_float.pony
+++ b/pony-odbc/sql_float.pony
@@ -1,0 +1,42 @@
+use "debug"
+use "stmt"
+
+class SQLFloat is SQLType
+  """
+  The internal class which represents an Integer (F32)
+  """
+  var _v: CBoxedArray = CBoxedArray
+  var _err: SQLReturn val = SQLSuccess
+
+  new create() => _v.alloc(20)
+
+  fun \nodoc\ ref get_boxed_array(): CBoxedArray => _v
+  fun \nodoc\ ref set_boxed_array(v': CBoxedArray) => _v = v'
+
+  fun \nodoc\ ref get_err(): SQLReturn val => _err
+  fun \nodoc\ ref set_err(err': SQLReturn val) => _err = err'
+
+  fun ref write(f32: F32): Bool =>
+    """
+    Write an F32 to this buffer as a string. The string will fit
+    as we defined the buffer to be characters on initialization.
+
+    Will return true if written and verification succeeds.
+
+    Will return false if the string is too long for the buffer or
+    the readback doesn't match for some other reason.
+    """
+    _write(f32.string())
+
+  fun ref read(): F32 ? =>
+    """
+    Read the value of the buffer and convert it into an F32.
+    
+    This function is partial just in case the string version
+    that comes from the database is not within the F32 range.
+
+    NOTE: SQLite does not enforce type limits, so if you use
+    that specific ODBC driver, this is something that must be
+    verified.
+    """
+    _v.string().f32()?

--- a/pony-odbc/sql_integer.pony
+++ b/pony-odbc/sql_integer.pony
@@ -1,0 +1,42 @@
+use "debug"
+use "stmt"
+
+class SQLInteger is SQLType
+  """
+  The internal class which represents an Integer (I32)
+  """
+  var _v: CBoxedArray = CBoxedArray
+  var _err: SQLReturn val = SQLSuccess
+
+  new create() => _v.alloc(15)
+
+  fun \nodoc\ ref get_boxed_array(): CBoxedArray => _v
+  fun \nodoc\ ref set_boxed_array(v': CBoxedArray) => _v = v'
+
+  fun \nodoc\ ref get_err(): SQLReturn val => _err
+  fun \nodoc\ ref set_err(err': SQLReturn val) => _err = err'
+
+  fun ref write(i32: I32): Bool =>
+    """
+    Write an I32 to this buffer as a string. The string will fit
+    as we defined the buffer to be characters on initialization.
+
+    Will return true if written and verification succeeds.
+
+    Will return false if the string is too long for the buffer or
+    the readback doesn't match for some other reason.
+    """
+    _write(i32.string())
+
+  fun ref read(): I32 ? =>
+    """
+    Read the value of the buffer and convert it into an I32.
+    
+    This function is partial just in case the string version
+    that comes from the database is not within the I32 range.
+
+    NOTE: SQLite does not enforce type limits, so if you use
+    that specific ODBC driver, this is something that must be
+    verified.
+    """
+    _v.string().i32()?

--- a/pony-odbc/sql_real.pony
+++ b/pony-odbc/sql_real.pony
@@ -1,0 +1,42 @@
+use "debug"
+use "stmt"
+
+class SQLReal is SQLType
+  """
+  The internal class which represents an Integer (F32)
+  """
+  var _v: CBoxedArray = CBoxedArray
+  var _err: SQLReturn val = SQLSuccess
+
+  new create() => _v.alloc(30)
+
+  fun \nodoc\ ref get_boxed_array(): CBoxedArray => _v
+  fun \nodoc\ ref set_boxed_array(v': CBoxedArray) => _v = v'
+
+  fun \nodoc\ ref get_err(): SQLReturn val => _err
+  fun \nodoc\ ref set_err(err': SQLReturn val) => _err = err'
+
+  fun ref write(f64: F64): Bool =>
+    """
+    Write an F64 to this buffer as a string. The string will fit
+    as we defined the buffer to be characters on initialization.
+
+    Will return true if written and verification succeeds.
+
+    Will return false if the string is too long for the buffer or
+    the readback doesn't match for some other reason.
+    """
+    _write(f64.string())
+
+  fun ref read(): F64 ? =>
+    """
+    Read the value of the buffer and convert it into an F64.
+    
+    This function is partial just in case the string version
+    that comes from the database is not within the F64 range.
+
+    NOTE: SQLite does not enforce type limits, so if you use
+    that specific ODBC driver, this is something that must be
+    verified.
+    """
+    _v.string().f64()?

--- a/pony-odbc/sql_small_int.pony
+++ b/pony-odbc/sql_small_int.pony
@@ -1,0 +1,42 @@
+use "debug"
+use "stmt"
+
+class SQLSmallInteger is SQLType
+  """
+  The internal class which represents an Integer (I16)
+  """
+  var _v: CBoxedArray = CBoxedArray
+  var _err: SQLReturn val = SQLSuccess
+
+  new create() => _v.alloc(8)
+
+  fun \nodoc\ ref get_boxed_array(): CBoxedArray => _v
+  fun \nodoc\ ref set_boxed_array(v': CBoxedArray) => _v = v'
+
+  fun \nodoc\ ref get_err(): SQLReturn val => _err
+  fun \nodoc\ ref set_err(err': SQLReturn val) => _err = err'
+
+  fun ref write(i16: I16): Bool =>
+    """
+    Write an I16 to this buffer as a string. The string will fit
+    as we defined the buffer to be characters on initialization.
+
+    Will return true if written and verification succeeds.
+
+    Will return false if the string is too long for the buffer or
+    the readback doesn't match for some other reason.
+    """
+    _write(i16.string())
+
+  fun ref read(): I16 ? =>
+    """
+    Read the value of the buffer and convert it into an I16.
+    
+    This function is partial just in case the string version
+    that comes from the database is not within the I16 range.
+
+    NOTE: SQLite does not enforce type limits, so if you use
+    that specific ODBC driver, this is something that must be
+    verified.
+    """
+    _v.string().i16()?

--- a/pony-odbc/sql_type.pony
+++ b/pony-odbc/sql_type.pony
@@ -1,0 +1,113 @@
+use "stmt"
+
+trait SQLType
+  """
+  The most portable implementation of ODBC when reading and writing across
+  the various database vendors has been as textual data via a buffer.
+
+  Given this, we have implemented our SQL Datatypes in two halves - a
+  "front-end" class, and this back-end SQLType.
+
+  This class is responsible for allocating, binding, reallocating,
+  reading, and writing the buffers with the database.
+
+  The front-end class is responsible for translating the data to and
+  from the native pony datatype.
+
+  You should only need to refer to this trait if you are implementing
+  a missing SQL datatype.
+
+  ## Implemented Types:
+
+  * SQLVarchar
+  * SQLChar
+  * SQLText
+  * SQLInteger
+  """
+
+  fun \nodoc\ ref get_boxed_array(): CBoxedArray
+  fun \nodoc\ ref set_boxed_array(v: CBoxedArray)
+
+  fun \nodoc\ ref get_err(): SQLReturn val
+  fun \nodoc\ ref set_err(err: SQLReturn val)
+
+  fun \nodoc\ ref alloc(size: USize): Bool =>
+    get_boxed_array().alloc(size)
+
+  fun \nodoc\ ref reset(): Bool =>
+    """
+    Zeros the buffer and resets the field that defines the length of
+    data written.
+    """
+    get_boxed_array().reset()
+
+  fun \nodoc\ ref string(): String iso^ =>
+    """
+    Returns the written contents of the buffer as a string
+    """
+    get_boxed_array().string()
+
+  fun \nodoc\ ref array(): Array[U8] iso^ =>
+    """
+    Returns the written contents of the buffer as an array.
+    """
+    get_boxed_array().array()
+
+  fun \nodoc\ ref _write(str: String val): Bool =>
+    """
+    Writes the string into the provided buffer. If the string is
+    larger than the buffer then it will FAIL, not re-allocate.
+
+    (We can't reallocate, just in case this buffer is already bound
+    to a query already)
+    """
+    if (not get_boxed_array().write(str)) then return false end
+    if (str != get_boxed_array().string()) then return false end
+    true
+
+  fun \nodoc\ ref _write_array(arr: Array[U8] val): Bool =>
+    """
+    Writes the string into the provided buffer. If the string is
+    larger than the buffer then it will FAIL, not re-allocate.
+
+    (We can't reallocate, just in case this buffer is already bound
+    to a query already)
+    """
+    if (not get_boxed_array().write_array(arr)) then return false end
+    true
+
+  fun \nodoc\ ref bind_parameter(h: ODBCHandleStmt tag, col: U16): SQLReturn val =>
+    if (not _bind_parameter(h, col)) then
+      return get_err()
+    end
+    get_err()
+
+  fun \nodoc\ ref _bind_parameter(h: ODBCHandleStmt tag, col: U16): Bool =>
+    set_err(ODBCStmtFFI.bind_parameter_varchar(h, col, get_boxed_array()))
+    is_success()
+
+  fun \nodoc\ ref is_success(): Bool =>
+    match get_err()
+    | let x: SQLSuccess => true
+    else
+      false
+    end
+
+  fun \nodoc\ ref realloc_column(h: ODBCHandleStmt tag, size: USize, col: U16): SQLReturn val =>
+    """
+    Reallocates the buffer to be populated by the database when data
+    is fetched and rebinds the new buffer to the column.
+    """
+    set_boxed_array(CBoxedArray .> alloc(size))
+    bind_column(h, col)
+
+  fun \nodoc\ ref bind_column(h: ODBCHandleStmt tag, col: U16): SQLReturn val =>
+    if (not _bind_column(h, col)) then
+      return get_err()
+    end
+    get_err()
+
+  fun \nodoc\ ref _bind_column(h: ODBCHandleStmt tag, col: U16): Bool =>
+    set_err(ODBCStmtFFI.bind_column_varchar(h, col, get_boxed_array()))
+    is_success()
+

--- a/pony-odbc/sql_varbinary.pony
+++ b/pony-odbc/sql_varbinary.pony
@@ -1,16 +1,16 @@
 use "debug"
 use "stmt"
 
-class SQLVarchar is SQLType
+class SQLVarbinary is SQLType
   """
-  The internal class which represents a CHAR, VARCHAR, or TEXT
+  The internal class which represents a binary blob
   """
   var _v: CBoxedArray = CBoxedArray
   var _err: SQLReturn val = SQLSuccess
 
   new create(size: USize) => _v.alloc(size)
     """
-    Creates a SQLVarchar to be used as an input or output buffer.
+    Creates a SQLVarbinary to be used as an input or output buffer.
     """
 
   fun \nodoc\ ref get_boxed_array(): CBoxedArray => _v
@@ -19,7 +19,7 @@ class SQLVarchar is SQLType
   fun \nodoc\ ref get_err(): SQLReturn val => _err
   fun \nodoc\ ref set_err(err': SQLReturn val) => _err = err'
 
-  fun ref write(str: String val): Bool =>
+  fun ref write(str: Array[U8] val): Bool =>
     """
     Write a string to this buffer.  The string MUST fit in
     the defined buffer.
@@ -29,13 +29,13 @@ class SQLVarchar is SQLType
     Will return false if the string is too long for the buffer or
     the readback doesn't match for some other reason.
     """
-    _write(str)
+    _write_array(str)
 
 
-  fun ref read(): String iso^ =>
+  fun ref read(): Array[U8] iso^ =>
     """
     Read the value of the buffer into a String iso^. This is an iso^
     copy of the data so the buffer can remain in place and reused
     without rebinding.
     """
-    _v.string()
+    _v.array()

--- a/pony-odbc/tests/_test.pony
+++ b/pony-odbc/tests/_test.pony
@@ -30,6 +30,10 @@ actor \nodoc\ Main is TestList
     test(_TestStmtAPI("mariadb"))
     test(_TestStmtAPI("sqlitedb3"))
 
+    test(_TestTypeTests("psqlred"))
+    test(_TestTypeTests("mariadb"))
+    test(_TestTypeTests("sqlitedb3"))
+
   fun show_error_dbc(dbc: ODBCDbc) =>
     var err: SQLReturn val = recover val SQLError.create_pdbc(dbc.dbc) end
     try
@@ -38,140 +42,5 @@ actor \nodoc\ Main is TestList
         Debug.out(f)
       end
       true
-    end
-
-class \nodoc\ iso _TestStmtAPI is UnitTest
-  var dsn: String val
-  fun name(): String val => "_TestStmtAPI(" + dsn + ")"
-
-  new create(dsn': String val) => dsn = dsn'
-
-  fun apply(h: TestHelper) =>
-    var dbc: ODBCDbc = ODBCDbc(ODBCEnv.>set_odbc3())
-
-    h.assert_true(dbc.connect(dsn))
-    h.assert_eq[String]("SQLSuccess", dbc.get_err().string())
-
-    create_temp_table(h, dbc)
-    populate_temp_table(h, dbc)
-    query_test_rowcounts(h, dbc)
-    query_test_under_allocation(h, dbc)
-
-
-  fun create_temp_table(h: TestHelper, dbc: ODBCDbc) =>
-    var stm: ODBCStmt = ODBCStmt(dbc)
-    try
-      stm
-      .>prepare("create temporary table odbthingtest (i integer, s varchar(100))")?
-      .>execute()?
-    else
-      Debug.out("Something in there failed")
-      try
-        for f in (stm.get_err() as SQLError val).get_records().values() do
-          h.fail(f)
-        end
-      end
-    end
-
-  fun populate_temp_table(h: TestHelper, dbc: ODBCDbc) =>
-    var stm: ODBCStmt = ODBCStmt(dbc)
-    var pina: (SQLVarchar, SQLVarchar) = (SQLVarchar.>alloc(20), SQLVarchar.>alloc(101))
-    try
-      stm
-      .>prepare("insert into odbthingtest (i, s) values (?,?)")?
-      .>bind_parameter(pina._1)?
-      .>bind_parameter(pina._2)?
-
-      for f in Range[I32](0,300) do
-        pina._1.write(f.string())
-        pina._2.write("A Number: " + f.string())
-        stm.execute()?
-      end
-    else
-      try
-        for f in (stm.get_err() as SQLError val).get_records().values() do
-          h.fail(f)
-        end
-      end
-    end
-
-  fun query_test_rowcounts(h: TestHelper, dbc: ODBCDbc) =>
-    var pinb: SQLVarchar = SQLVarchar.>alloc(25)
-    var poutb: (SQLVarchar, SQLVarchar) = (SQLVarchar.>alloc(25), SQLVarchar.>alloc(101))
-    var stm: ODBCStmt = ODBCStmt(dbc)
-    try
-      stm.prepare("select * from odbthingtest where i >= ?")?
-      stm.bind_parameter(pinb)?
-      stm.bind_column(poutb._1)?
-      stm.bind_column(poutb._2)?
-      pinb.write(I16(-1).string())
-      stm.execute()?
-      if (dsn != "sqlitedb3") then
-        h.assert_eq[I64](300, stm.rowcount()?)
-      end
-      stm.finish()?
-
-      pinb.write("150")
-      stm.execute()?
-      if (dsn != "sqlitedb3") then
-        h.assert_eq[I64](150, stm.rowcount()?)
-      end
-      stm.finish()?
-
-      pinb.write("290")
-      stm.execute()?
-      if (dsn != "sqlitedb3") then
-        h.assert_eq[I64](10, stm.rowcount()?)
-      end
-      stm.finish()?
-    else
-      try
-        for f in (stm.get_err() as SQLError val).get_records().values() do
-          h.fail(f)
-        end
-      else
-        Debug.out("Got err as: " + stm.get_err().string())
-      end
-    end
-
-  fun query_test_under_allocation(h: TestHelper, dbc: ODBCDbc) =>
-    var pinb: SQLVarchar = SQLVarchar.>alloc(25)
-    var poutb: (SQLVarchar, SQLVarchar) = (SQLVarchar.>alloc(25), SQLVarchar.>alloc(3))
-    var stm: ODBCStmt = ODBCStmt(dbc)
-    try
-      stm.prepare("select * from odbthingtest where i >= ?")?
-      stm.bind_parameter(pinb)?
-      stm.bind_column(poutb._1)?
-      stm.bind_column(poutb._2)?
-
-      pinb.write("298")
-      stm.execute()?
-      if (dsn != "sqlitedb3") then
-        h.assert_eq[I64](2, stm.rowcount()?)
-      end
-
-      try
-        var cntr: USize = 298
-        while stm.fetch_scroll(SqlFetchNext)? do
-          h.assert_eq[String](cntr.string(), poutb._1.string())
-          h.assert_eq[String]("A Number: " + cntr.string(), poutb._2.string())
-          cntr = cntr + 1
-        end
-        stm.finish()?
-      else
-        try
-          for f in (stm.get_err() as SQLSuccessWithInfo val).get_records().values() do
-            h.fail(f)
-          end
-        end
-      end
-    else
-      try
-        for f in (stm.get_err() as SQLError val).get_records().values() do
-          h.fail(f)
-        end
-      else
-        Debug.out("Got err as: " + stm.get_err().string())
-      end
     end
 

--- a/pony-odbc/tests/stmt_api.pony
+++ b/pony-odbc/tests/stmt_api.pony
@@ -1,0 +1,143 @@
+use "debug"
+use "lib:odbc"
+use "pony_test"
+use ".."
+use "../env"
+use "../dbc"
+use "../stmt"
+use "collections"
+
+class \nodoc\ iso _TestStmtAPI is UnitTest
+  var dsn: String val
+  fun name(): String val => "_TestStmtAPI(" + dsn + ")"
+
+  new create(dsn': String val) => dsn = dsn'
+
+  fun apply(h: TestHelper) =>
+    var dbc: ODBCDbc = ODBCDbc(ODBCEnv.>set_odbc3())
+
+    h.assert_true(dbc.connect(dsn))
+    h.assert_eq[String]("SQLSuccess", dbc.get_err().string())
+
+    create_temp_table(h, dbc)
+    populate_temp_table(h, dbc)
+    query_test_rowcounts(h, dbc)
+    query_test_under_allocation(h, dbc)
+
+
+  fun create_temp_table(h: TestHelper, dbc: ODBCDbc) =>
+    var stm: ODBCStmt = ODBCStmt(dbc)
+    try
+      stm
+      .>prepare("create temporary table odbthingtest (i integer, s varchar(100))")?
+      .>execute()?
+    else
+      Debug.out("Something in there failed")
+      try
+        for f in (stm.get_err() as SQLError val).get_records().values() do
+          h.fail(f)
+        end
+      end
+    end
+
+  fun populate_temp_table(h: TestHelper, dbc: ODBCDbc) =>
+    var stm: ODBCStmt = ODBCStmt(dbc)
+    var pina: (SQLInteger, SQLVarchar) = (SQLInteger, SQLVarchar(101))
+    try
+      stm
+      .>prepare("insert into odbthingtest (i, s) values (?,?)")?
+      .>bind_parameter(pina._1)?
+      .>bind_parameter(pina._2)?
+
+      for f in Range[I32](0,300) do
+        pina._1.write(f)
+        pina._2.write("A Number: " + f.string())
+        stm.execute()?
+      end
+    else
+      try
+        for f in (stm.get_err() as SQLError val).get_records().values() do
+          h.fail(f)
+        end
+      end
+    end
+
+  fun query_test_rowcounts(h: TestHelper, dbc: ODBCDbc) =>
+    var pinb: SQLInteger = SQLInteger
+    var poutb: (SQLInteger, SQLVarchar) = (SQLInteger, SQLVarchar(101))
+    var stm: ODBCStmt = ODBCStmt(dbc)
+    try
+      stm.prepare("select * from odbthingtest where i >= ?")?
+      stm.bind_parameter(pinb)?
+      stm.bind_column(poutb._1)?
+      stm.bind_column(poutb._2)?
+      pinb.write(-1)
+      stm.execute()?
+      if (dsn != "sqlitedb3") then
+        h.assert_eq[I64](300, stm.rowcount()?)
+      end
+      stm.finish()?
+
+      pinb.write(150)
+      stm.execute()?
+      if (dsn != "sqlitedb3") then
+        h.assert_eq[I64](150, stm.rowcount()?)
+      end
+      stm.finish()?
+
+      pinb.write(290)
+      stm.execute()?
+      if (dsn != "sqlitedb3") then
+        h.assert_eq[I64](10, stm.rowcount()?)
+      end
+      stm.finish()?
+    else
+      try
+        for f in (stm.get_err() as SQLError val).get_records().values() do
+          h.fail(f)
+        end
+      else
+        Debug.out("Got err as: " + stm.get_err().string())
+      end
+    end
+
+  fun query_test_under_allocation(h: TestHelper, dbc: ODBCDbc) =>
+    var pinb: SQLInteger = SQLInteger
+    var poutb: (SQLInteger, SQLVarchar) = (SQLInteger, SQLVarchar(3))
+    var stm: ODBCStmt = ODBCStmt(dbc)
+    try
+      stm.prepare("select * from odbthingtest where i >= ?")?
+      stm.bind_parameter(pinb)?
+      stm.bind_column(poutb._1)?
+      stm.bind_column(poutb._2)?
+
+      pinb.write(298)
+      stm.execute()?
+      if (dsn != "sqlitedb3") then
+        h.assert_eq[I64](2, stm.rowcount()?)
+      end
+
+      try
+        var cntr: I32 = 298
+        while stm.fetch_scroll(SqlFetchNext)? do
+          h.assert_eq[I32](cntr, poutb._1.read()?)
+          h.assert_eq[String]("A Number: " + cntr.string(), poutb._2.read())
+          cntr = cntr + 1
+        end
+        stm.finish()?
+      else
+        try
+          for f in (stm.get_err() as SQLSuccessWithInfo val).get_records().values() do
+            h.fail(f)
+          end
+        end
+      end
+    else
+      try
+        for f in (stm.get_err() as SQLError val).get_records().values() do
+          h.fail(f)
+        end
+      else
+        Debug.out("Got err as: " + stm.get_err().string())
+      end
+    end

--- a/pony-odbc/tests/type_tests.pony
+++ b/pony-odbc/tests/type_tests.pony
@@ -1,0 +1,190 @@
+use "debug"
+use "lib:odbc"
+use "pony_test"
+use ".."
+use "../env"
+use "../dbc"
+use "../stmt"
+use "collections"
+
+class \nodoc\ iso _TestTypeTests is UnitTest
+  var dsn: String val
+  fun name(): String val => "_TestTypeTests(" + dsn + ")"
+
+  new create(dsn': String val) => dsn = dsn'
+
+  fun apply(h: TestHelper) =>
+    var dbc: ODBCDbc = ODBCDbc(ODBCEnv.>set_odbc3())
+
+    h.assert_true(dbc.connect(dsn))
+    h.assert_eq[String]("SQLSuccess", dbc.get_err().string())
+
+    create_temp_table(h, dbc)
+    populate_temp_table(h, dbc)
+    query_test_rowcounts(h, dbc)
+    query_test_under_allocation(h, dbc)
+
+
+  fun create_temp_table(h: TestHelper, dbc: ODBCDbc) =>
+    var stm: ODBCStmt = ODBCStmt(dbc)
+    try
+      if (dsn == "psqlred") then
+        stm
+        .>prepare("create temporary table typetest (" +
+                  "si smallint, " +
+                  "ii integer, " +
+                  "bi bigint, " +
+                  "fl float, " +
+                  "rl real, " +
+                  "vc varchar(100), " +
+                  "vb bytea)")?
+        .>execute()?
+      else
+        stm
+        .>prepare("create temporary table typetest (" +
+                  "si smallint, " +
+                  "ii integer, " +
+                  "bi bigint, " +
+                  "fl float, " +
+                  "rl real, " +
+                  "vc varchar(100), " +
+                  "vb varbinary(100))")?
+        .>execute()?
+      end
+    else
+      Debug.out("Something in there failed")
+      try
+        for f in (stm.get_err() as SQLError val).get_records().values() do
+          h.fail(f)
+        end
+      end
+    end
+
+  fun populate_temp_table(h: TestHelper, dbc: ODBCDbc) =>
+    var stm: ODBCStmt = ODBCStmt(dbc)
+    var pina: (SQLSmallInteger, SQLInteger, SQLBigInteger, SQLFloat, SQLReal, SQLVarchar, SQLVarbinary) = (SQLSmallInteger, SQLInteger, SQLBigInteger, SQLFloat, SQLReal, SQLVarchar(100), SQLVarbinary(100))
+    try
+      stm
+      .>prepare("insert into typetest values (?,?,?,?,?,?,?)")?
+      .>bind_parameter(pina._1)?
+      .>bind_parameter(pina._2)?
+      .>bind_parameter(pina._3)?
+      .>bind_parameter(pina._4)?
+      .>bind_parameter(pina._5)?
+      .>bind_parameter(pina._6)?
+      .>bind_parameter(pina._7)?
+
+      for f in Range[USize](0,300) do
+        pina._1.write(f.i16())
+        pina._2.write(f.i32())
+        pina._3.write(f.i64())
+        pina._4.write((f.f32()+0.5).f32())
+        pina._5.write((f.f64()+0.5).f64())
+        pina._6.write(f.string())
+        pina._7.write([0;42;12;41;252;13])
+        stm.execute()?
+      end
+    else
+      try
+        for f in (stm.get_err() as SQLError val).get_records().values() do
+          h.fail(f)
+        end
+      end
+    end
+
+  fun query_test_rowcounts(h: TestHelper, dbc: ODBCDbc) =>
+    var pinb: SQLSmallInteger = SQLSmallInteger
+    var poutb: (SQLSmallInteger, SQLInteger, SQLBigInteger, SQLFloat, SQLReal, SQLVarchar, SQLVarbinary) = (SQLSmallInteger, SQLInteger, SQLBigInteger, SQLFloat, SQLReal, SQLVarchar(100), SQLVarbinary(100))
+    var stm: ODBCStmt = ODBCStmt(dbc)
+    try
+      stm.prepare("select * from typetest where si >= ?")?
+      stm.bind_parameter(pinb)?
+      stm.bind_column(poutb._1)?
+      stm.bind_column(poutb._2)?
+      stm.bind_column(poutb._3)?
+      stm.bind_column(poutb._4)?
+      stm.bind_column(poutb._5)?
+      stm.bind_column(poutb._6)?
+      stm.bind_column(poutb._7)?
+      pinb.write(-1)
+      stm.execute()?
+      if (dsn != "sqlitedb3") then
+        h.assert_eq[I64](300, stm.rowcount()?)
+      end
+      stm.finish()?
+
+      pinb.write(150)
+      stm.execute()?
+      if (dsn != "sqlitedb3") then
+        h.assert_eq[I64](150, stm.rowcount()?)
+      end
+      stm.finish()?
+
+      pinb.write(290)
+      stm.execute()?
+      if (dsn != "sqlitedb3") then
+        h.assert_eq[I64](10, stm.rowcount()?)
+      end
+      stm.finish()?
+    else
+      try
+        for f in (stm.get_err() as SQLError val).get_records().values() do
+          h.fail(f)
+        end
+      else
+        Debug.out("Got err as: " + stm.get_err().string())
+      end
+    end
+
+  fun query_test_under_allocation(h: TestHelper, dbc: ODBCDbc) =>
+    var pinb: SQLInteger = SQLInteger
+    var poutb: (SQLSmallInteger, SQLInteger, SQLBigInteger, SQLFloat, SQLReal, SQLVarchar, SQLVarbinary) = (SQLSmallInteger, SQLInteger, SQLBigInteger, SQLFloat, SQLReal, SQLVarchar(100), SQLVarbinary(100))
+    var stm: ODBCStmt = ODBCStmt(dbc)
+    try
+      stm.prepare("select * from typetest where ii >= ?")?
+      stm.bind_parameter(pinb)?
+      stm.bind_column(poutb._1)?
+      stm.bind_column(poutb._2)?
+      stm.bind_column(poutb._3)?
+      stm.bind_column(poutb._4)?
+      stm.bind_column(poutb._5)?
+      stm.bind_column(poutb._6)?
+      stm.bind_column(poutb._7)?
+
+      pinb.write(298)
+      stm.execute()?
+      if (dsn != "sqlitedb3") then
+        h.assert_eq[I64](2, stm.rowcount()?)
+      end
+      try
+        var cntr: I32 = 298
+        while stm.fetch_scroll(SqlFetchNext)? do
+          h.assert_eq[I16](cntr.i16(), poutb._1.read()?)
+          h.assert_eq[I32](cntr, poutb._2.read()?)
+          h.assert_eq[I64](cntr.i64(), poutb._3.read()?)
+          h.assert_eq[F32]((cntr.f32()+0.5), poutb._4.read()?)
+          h.assert_eq[F64]((cntr.f64()+0.5), poutb._5.read()?)
+          h.assert_eq[String](cntr.string(), poutb._6.read())
+//          h.assert_eq[USize](6, poutb._7.read().size())
+//          h.assert_eq[I32](cntr, poutb._7.read()?)
+          cntr = cntr + 1
+//        pina._4.write((f.f32() * 0.332).f32())
+//        pina._5.write((f.f64() * 0.00332).f64())
+        end
+        stm.finish()?
+      else
+        try
+          for f in (stm.get_err() as SQLSuccessWithInfo val).get_records().values() do
+            h.fail(f)
+          end
+        end
+      end
+    else
+      try
+        for f in (stm.get_err() as SQLError val).get_records().values() do
+          h.fail(f)
+        end
+      else
+        Debug.out("Got err as: " + stm.get_err().string())
+      end
+    end


### PR DESCRIPTION
Broke out backend of types to SQLType trait

* Created and documented SQLType trait.
* SQLVarchar and SQLInteger are implemented.
* Added documentation for SQLVarchar and SQLInteger.
* Added create() to SQLVarchar.
* Each type gates through read()? and write().
* Types are "open-world" so can be added by end-users.
* Added new types and tests for them:
  - SQLSmallInteger
  - SQLBigInteger
  - SQLFloat
  - SQLReal
  - SQLVarbinary (to fix)
