### PR TITLE
Transactions now implemented and tested.

### DIFF
--- a/pony-odbc/odbc_dbc.pony
+++ b/pony-odbc/odbc_dbc.pony
@@ -21,9 +21,42 @@ class ODBCDbc
     (_err, dbc) = ODBCDbcFFI.alloc(_henv.odbcenv)
     _set_valid(_err)
 
+  fun ref get_autocommit(): Bool ? =>
+    (_err, var value: I32) = ODBCDbcFFI.get_attr_i32(dbc, SqlAttrAutoCommit)
+    _set_valid(_err)
+    if (value == SqlAutoCommitOn()) then return true end
+    if (value == SqlAutoCommitOff()) then return false end
+    error
+
+  fun ref set_autocommit(setting: Bool) =>
+    if (setting) then
+      _err = ODBCDbcFFI.set_attr_i32(dbc, SqlAttrAutoCommit, SqlAutoCommitOn())
+    else
+      _err = ODBCDbcFFI.set_attr_i32(dbc, SqlAttrAutoCommit, SqlAutoCommitOff())
+    end
+    _set_valid(_err)
+
   fun ref get_info(i: SQLInfoTypes, sl: SourceLoc val = __loc): (SQLReturn val, String val) =>
     _call_location = sl
     ODBCDbcFFI.get_info(dbc, i)
+
+  fun ref commit(sl: SourceLoc val = __loc): Bool =>
+    """
+    Instructs the database to commit your transaction and open a new one.
+    """
+    _call_location = sl
+    _err = ODBCDbcFFI.commit(dbc)
+    _set_valid(_err)
+    _valid
+
+  fun ref rollback(sl: SourceLoc val = __loc): Bool =>
+    """
+    Instructs the database to rollback your transaction and open a new one.
+    """
+    _call_location = sl
+    _err = ODBCDbcFFI.rollback(dbc)
+    _set_valid(_err)
+    _valid
 
 
   fun ref set_application_name(appname: String val, sl: SourceLoc val = __loc): Bool =>

--- a/pony-odbc/tests/_test.pony
+++ b/pony-odbc/tests/_test.pony
@@ -34,6 +34,10 @@ actor \nodoc\ Main is TestList
     test(_TestTypeTests("mariadb"))
     test(_TestTypeTests("sqlitedb3"))
 
+    test(_TestTransactions("psqlred"))
+    test(_TestTransactions("mariadb"))
+    test(_TestTransactions("sqlitedb3"))
+
   fun show_error_dbc(dbc: ODBCDbc) =>
     var err: SQLReturn val = recover val SQLError.create_pdbc(dbc.dbc) end
     try

--- a/pony-odbc/tests/transactions.pony
+++ b/pony-odbc/tests/transactions.pony
@@ -1,0 +1,164 @@
+use "debug"
+use "lib:odbc"
+use "pony_test"
+use ".."
+use "../env"
+use "../dbc"
+use "../stmt"
+use "collections"
+
+class \nodoc\ iso _TestTransactions is UnitTest
+  var dsn: String val
+  fun name(): String val => "_TestTransactions(" + dsn + ")"
+
+  new create(dsn': String val) => dsn = dsn'
+
+  fun apply(h: TestHelper) ? =>
+    var dbc: ODBCDbc = ODBCDbc(ODBCEnv.>set_odbc3())
+
+    h.assert_true(dbc.connect(dsn))
+    h.assert_eq[String]("SQLSuccess", dbc.get_err().string())
+
+    h.assert_true(dbc.get_autocommit()?)
+    showerr(dbc.get_err())
+    dbc.set_autocommit(false)
+    showerr(dbc.get_err())
+    h.assert_false(dbc.get_autocommit()?)
+    showerr(dbc.get_err())
+    dbc.set_autocommit(true)
+    showerr(dbc.get_err())
+    h.assert_true(dbc.get_autocommit()?)
+    dbc.set_autocommit(false)
+    showerr(dbc.get_err())
+    h.assert_false(dbc.get_autocommit()?)
+
+    create_temp_table(h, dbc)
+    h.assert_true(dbc.commit())
+    populate_temp_table(h, dbc)
+    h.assert_true(dbc.rollback())
+    populate_temp_table(h, dbc)
+    query_test_rowcounts(h, dbc)
+    query_test_under_allocation(h, dbc)
+
+
+  fun create_temp_table(h: TestHelper, dbc: ODBCDbc) =>
+    var stm: ODBCStmt = ODBCStmt(dbc)
+    try
+      stm
+      .>prepare("create temporary table transactiontest (i integer, s varchar(100))")?
+      .>execute()?
+    else
+      Debug.out("Something in there failed")
+      try
+        for f in (stm.get_err() as SQLError val).get_records().values() do
+          h.fail(f)
+        end
+      end
+    end
+
+  fun populate_temp_table(h: TestHelper, dbc: ODBCDbc) =>
+    var stm: ODBCStmt = ODBCStmt(dbc)
+    var pina: (SQLInteger, SQLVarchar) = (SQLInteger, SQLVarchar(101))
+    try
+      stm
+      .>prepare("insert into transactiontest (i, s) values (?,?)")?
+      .>bind_parameter(pina._1)?
+      .>bind_parameter(pina._2)?
+
+      for f in Range[I32](0,300) do
+        pina._1.write(f)
+        pina._2.write("A Number: " + f.string())
+        stm.execute()?
+      end
+    else
+      try
+        for f in (stm.get_err() as SQLError val).get_records().values() do
+          h.fail(f)
+        end
+      end
+    end
+
+  fun query_test_rowcounts(h: TestHelper, dbc: ODBCDbc) =>
+    var pinb: SQLInteger = SQLInteger
+    var poutb: (SQLInteger, SQLVarchar) = (SQLInteger, SQLVarchar(101))
+    var stm: ODBCStmt = ODBCStmt(dbc)
+    try
+      stm.prepare("select * from transactiontest where i >= ?")?
+      stm.bind_parameter(pinb)?
+      stm.bind_column(poutb._1)?
+      stm.bind_column(poutb._2)?
+      pinb.write(-1)
+      stm.execute()?
+      if (dsn != "sqlitedb3") then
+        h.assert_eq[I64](300, stm.rowcount()?)
+      end
+      stm.finish()?
+
+      pinb.write(150)
+      stm.execute()?
+      if (dsn != "sqlitedb3") then
+        h.assert_eq[I64](150, stm.rowcount()?)
+      end
+      stm.finish()?
+
+      pinb.write(290)
+      stm.execute()?
+      if (dsn != "sqlitedb3") then
+        h.assert_eq[I64](10, stm.rowcount()?)
+      end
+      stm.finish()?
+    else
+      try
+        for f in (stm.get_err() as SQLError val).get_records().values() do
+          h.fail(f)
+        end
+      else
+        Debug.out("Got err as: " + stm.get_err().string())
+      end
+    end
+
+  fun query_test_under_allocation(h: TestHelper, dbc: ODBCDbc) =>
+    var pinb: SQLInteger = SQLInteger
+    var poutb: (SQLInteger, SQLVarchar) = (SQLInteger, SQLVarchar(3))
+    var stm: ODBCStmt = ODBCStmt(dbc)
+    try
+      stm.prepare("select * from transactiontest where i >= ?")?
+      stm.bind_parameter(pinb)?
+      stm.bind_column(poutb._1)?
+      stm.bind_column(poutb._2)?
+
+      pinb.write(298)
+      stm.execute()?
+      if (dsn != "sqlitedb3") then
+        h.assert_eq[I64](2, stm.rowcount()?)
+      end
+
+      try
+        var cntr: I32 = 298
+        while stm.fetch_scroll(SqlFetchNext)? do
+          h.assert_eq[I32](cntr, poutb._1.read()?)
+          h.assert_eq[String]("A Number: " + cntr.string(), poutb._2.read())
+          cntr = cntr + 1
+        end
+        stm.finish()?
+      else
+        try
+          for f in (stm.get_err() as SQLSuccessWithInfo val).get_records().values() do
+            h.fail(f)
+          end
+        end
+      end
+    else
+      try
+        for f in (stm.get_err() as SQLError val).get_records().values() do
+          h.fail(f)
+        end
+      else
+        Debug.out("Got err as: " + stm.get_err().string())
+      end
+    end
+
+  fun showerr(r: SQLReturn val) =>
+    match r
+    | let x: SQLError val => Debug.out(x.get_err_strings())
+    end


### PR DESCRIPTION
Transactions:

* All (tested) databases start with AUTO_COMMIT on.
* Before you can use transactions, you must turn off AUTO_COMMIT by calling `.set_autocommit(false)` on your database object.
* The ODBC standard states that there is no "start transaction", it starts the moment you disable AUTO_COMMIT.
* You end a transaction by either calling `.commit()` or `.rollback()` on your *database* object.

The standard states that transactions can only apply at the environment or database level, never the statement level.

It is currently only implemented at the database connection level.
