### PR TITLE
Revamping the API for SQLError and SQLSuccessWithInfo

### DIFF
--- a/pony-odbc/odbc_stmt.pony
+++ b/pony-odbc/odbc_stmt.pony
@@ -228,7 +228,7 @@ class ODBCStmt
     _err = ODBCStmtFFI.fetch_scroll(_sth, d, offset)
     match _err
     | let x: SQLSuccess val => true
-    | let x: SQLSuccessWithInfo val => _check_columns()? ; true
+    | let x: SQLSuccessWithInfo val => _check_and_expand_column_buffers()?; true
     | let x: SQLNoData val => false
     | let x: SQLError val => _set_error_text(x) ; error
     else
@@ -251,7 +251,7 @@ class ODBCStmt
       error
     end
 
-  fun ref _check_columns(sl: SourceLoc val = __loc) ? =>
+  fun ref _check_and_expand_column_buffers(sl: SourceLoc val = __loc) ? =>
     _call_location = sl
     for (colindex, vc) in _columns.pairs() do
       if (vc.get_boxed_array().written_size.value.usize() > vc.get_boxed_array().alloc_size) then

--- a/pony-odbc/sql_error.pony
+++ b/pony-odbc/sql_error.pony
@@ -5,72 +5,90 @@ use "env"
 use "dbc"
 use "stmt"
 
-class \nodoc\ SQLError
-  var location: SourceLoc val = __loc
-  var records: Array[(I16, SQLDiagFrame)] = Array[(I16, SQLDiagFrame)]
+class SQLError
+  var _location: SourceLoc val = __loc
+  var _records: Array[(I16, SQLDiagFrame)] = Array[(I16, SQLDiagFrame)]
 
   fun apply(): I16 => -1
 
   fun string(): String val => "SQLError"
+
+  fun get_err_strings(): String val =>
+    _location.type_name() + "." +
+    _location.method_name() + "() returned the following error from ODBC\n\n" +
+    "\n".join(get_records().values())
+
+  new \nodoc\ create_penv(htype: ODBCHandleEnv tag, sl: SourceLoc val = __loc) => None
+    _location = sl
+    for num in Range[I16](1,1024) do
+      try
+        _records.push((num, SQLDiagFrame.create_penv(htype, num)?))
+      else
+        break
+      end
+    end
+
+  new \nodoc\ create_pdbc(htype: ODBCHandleDbc tag, sl: SourceLoc val = __loc) => None
+    _location = sl
+    for num in Range[I16](1,1024) do
+      try
+        _records.push((num, SQLDiagFrame.create_pdbc(htype, num)?))
+      else
+        break
+      end
+    end
+
+  new \nodoc\ create_pstmt(htype: ODBCHandleStmt tag, sl: SourceLoc val = __loc) =>
+    _location = sl
+    for num in Range[I16](1,1024) do
+      try
+        _records.push((num, SQLDiagFrame.create_pstmt(htype, num)?))
+      else
+        break
+      end
+    end
+
+  fun latest_sqlstate(): String val =>
+    """
+    Returns the latest SQLSTATE from this SQLError.
+    """
+    try
+      _records(_records.size() - 1)?._2.sqlstate.clone()
+    else
+      ""
+    end
+
+  fun sqlstates(): Array[String val] val =>
+    """
+    Returns an Array of SQLSTATEs in the order in which they were provided
+    to the driver.
+    """
+    var rs: USize = _records.size()
+    var rv: Array[String val] trn = recover trn Array[String val](rs) end
+    for (i,f) in _records.values() do
+      rv.push(f.sqlstate.clone())
+    end
+    consume rv
+
   fun get_records(): Array[String val] val =>
+    """
+    Returns an Array of human-readable strings suitable for logging.
+    """
     let rv: Array[String val] trn = recover trn Array[String val](8) end
-    for (i,f) in records.values() do
+    for (i,f) in _records.values() do
       rv.push(f.recstring())
     end
     consume rv
 
   fun get_tuples(): Array[(I16, String val, String val)] val =>
+    """
+    Returns an Array of tuples of the form:
+      - Index
+      - SQLSTATE
+      - Human readable error message
+    """
     let rv: Array[(I16, String val, String val)] trn = recover trn Array[(I16, String val, String val)](8) end
-    for (i,f) in records.values() do
+    for (i,f) in _records.values() do
       rv.push(f.rec_tuple())
     end
     consume rv
-
-  fun get_err_strings(): String val =>
-    location.type_name() + "." +
-    location.method_name() + "() returned the following error from ODBC\n\n" +
-    "\n".join(get_records().values())
-
-
-    /*
-  new create(htype: ODBCHandle) =>
-    for num in Range[I16](1,1024) do
-      try
-        records.push((num, SQLDiagFrame.create(htype, num)?))
-      else
-        break
-      end
-    end
-    */
-
-  new create_penv(htype: ODBCHandleEnv tag, sl: SourceLoc val = __loc) => None
-    location = sl
-    for num in Range[I16](1,1024) do
-      try
-        records.push((num, SQLDiagFrame.create_penv(htype, num)?))
-      else
-        break
-      end
-    end
-
-  new create_pdbc(htype: ODBCHandleDbc tag, sl: SourceLoc val = __loc) => None
-    location = sl
-    for num in Range[I16](1,1024) do
-      try
-        records.push((num, SQLDiagFrame.create_pdbc(htype, num)?))
-      else
-        break
-      end
-    end
-
-  new create_pstmt(htype: ODBCHandleStmt tag, sl: SourceLoc val = __loc) =>
-    location = sl
-    for num in Range[I16](1,1024) do
-      try
-        records.push((num, SQLDiagFrame.create_pstmt(htype, num)?))
-      else
-        break
-      end
-    end
-
-

--- a/pony-odbc/sql_success_with_info.pony
+++ b/pony-odbc/sql_success_with_info.pony
@@ -5,52 +5,82 @@ use "env"
 use "dbc"
 use "stmt"
 
-class \nodoc\ SQLSuccessWithInfo
-  var records: Array[(I16, SQLDiagFrame)] = Array[(I16, SQLDiagFrame)]
+class SQLSuccessWithInfo
+  var _locations: SourceLoc val = __loc
+  var _records: Array[(I16, SQLDiagFrame)] = Array[(I16, SQLDiagFrame)]
 
   fun string(): String val => "SQLSuccessWithInfo"
   fun apply(): I16 => 1
 
+  new \nodoc\ create_penv(htype: ODBCHandleEnv tag, sl: SourceLoc = __loc) =>
+    for num in Range[I16](1,1024) do
+      try
+        _records.push((num, SQLDiagFrame.create_penv(htype, num)?))
+      else
+        break
+      end
+    end
+
+  new \nodoc\ create_pdbc(htype: ODBCHandleDbc tag, sl: SourceLoc = __loc) =>
+    for num in Range[I16](1,1024) do
+      try
+        _records.push((num, SQLDiagFrame.create_pdbc(htype, num)?))
+      else
+        break
+      end
+    end
+
+  new \nodoc\ create_pstmt(htype: ODBCHandleStmt tag, sl: SourceLoc = __loc) =>
+    for num in Range[I16](1,1024) do
+      try
+        _records.push((num, SQLDiagFrame.create_pstmt(htype, num)?))
+      else
+        break
+      end
+    end
+
+  fun latest_sqlstate(): String val =>
+    """
+    Returns the latest SQLSTATE from this SQLSuccessWithInfo
+    """
+    try
+      _records(_records.size() - 1)?._2.sqlstate.clone()
+    else
+      ""
+    end
+
+  fun sqlstates(): Array[String val] val =>
+    """
+    Returns an Array of SQLSTATEs in the order in which they were provided
+    to the driver
+    """
+    var rs: USize = _records.size()
+    var rv: Array[String val] trn = recover trn Array[String val](rs) end
+    for (i,f) in _records.values() do
+      rv.push(f.sqlstate.clone())
+    end
+    consume rv
+
   fun get_records(): Array[String val] val =>
+    """
+    Returns an Array of human-readable strings suitable for logging
+    """
     let rv: Array[String val] trn = recover trn Array[String val](8) end
-    for (i,f) in records.values() do
+    for (i,f) in _records.values() do
       rv.push(f.recstring())
     end
     consume rv
 
   fun get_tuples(): Array[(I16, String val, String val)] val =>
+    """
+    Returns an Array of tuples of the form:
+      - Index
+      - SQLSTATE
+      - Human readable error message
+    """
     let rv: Array[(I16, String val, String val)] trn = recover trn Array[(I16, String val, String val)](8) end
-    for (i,f) in records.values() do
+    for (i,f) in _records.values() do
       rv.push(f.rec_tuple())
     end
     consume rv
-
-  new create_penv(htype: ODBCHandleEnv tag) =>
-    for num in Range[I16](1,1024) do
-      try
-        records.push((num, SQLDiagFrame.create_penv(htype, num)?))
-      else
-        break
-      end
-    end
-
-  new create_pdbc(htype: ODBCHandleDbc tag) =>
-    for num in Range[I16](1,1024) do
-      try
-        records.push((num, SQLDiagFrame.create_pdbc(htype, num)?))
-      else
-        break
-      end
-    end
-
-  new create_pstmt(htype: ODBCHandleStmt tag) =>
-    for num in Range[I16](1,1024) do
-      try
-        records.push((num, SQLDiagFrame.create_pstmt(htype, num)?))
-      else
-        break
-      end
-    end
-
-
 

--- a/pony-odbc/tests/_test.pony
+++ b/pony-odbc/tests/_test.pony
@@ -38,13 +38,3 @@ actor \nodoc\ Main is TestList
     test(_TestTransactions("mariadb"))
     test(_TestTransactions("sqlitedb3"))
 
-  fun show_error_dbc(dbc: ODBCDbc) =>
-    var err: SQLReturn val = recover val SQLError.create_pdbc(dbc.dbc) end
-    try
-      if (false) then error end
-      for f in (dbc.get_err() as SQLError val).get_records().values() do
-        Debug.out(f)
-      end
-      true
-    end
-

--- a/pony-odbc/tests/connects.pony
+++ b/pony-odbc/tests/connects.pony
@@ -9,7 +9,7 @@ use "../stmt"
 class \nodoc\ iso _TestConnects is UnitTest
   fun name(): String val => "_TestConnects"
 
-  fun apply(h: TestHelper) =>
+  fun apply(h: TestHelper) ? =>
     var e: ODBCEnv = ODBCEnv
     h.assert_true(e.is_valid())
     h.assert_true(e.set_odbc3())
@@ -21,77 +21,42 @@ class \nodoc\ iso _TestConnects is UnitTest
     // Unknown ODBC Identifier
     h.assert_false(dbc.connect("IDontExist"))
     h.assert_eq[String]("SQLError", dbc.get_err().string())
-
-    var err: SQLError val = SQLError.create_pdbc(dbc.dbc)
-    try
-      h.assert_eq[String val]("IM002", err.get_tuples()(0)?._2)
-    else
-      h.fail("SQLError contents not found: " + err.string())
-    end
+    h.assert_eq[String val]("IM002", (dbc.get_err() as SQLError val).latest_sqlstate())
+    h.assert_eq[USize](1, (dbc.get_err() as SQLError val).sqlstates().size())
 
     // Unknown Driver .so file
     h.assert_false(dbc.connect("psqlred_baddriver"))
     h.assert_eq[String]("SQLError", dbc.get_err().string())
-
-    err = SQLError.create_pdbc(dbc.dbc)
-    try
-      h.assert_eq[String val]("01000", err.get_tuples()(0)?._2)
-    else
-      h.fail("SQLError contents not found: " + err.string())
-    end
+    h.assert_eq[String val]("01000", (dbc.get_err() as SQLError val).latest_sqlstate())
+    h.assert_eq[USize](1, (dbc.get_err() as SQLError val).sqlstates().size())
 
     // Unknown PostgreSQL Server
     h.assert_false(dbc.connect("psqlred_badserver"))
     h.assert_eq[String]("SQLError", dbc.get_err().string())
-
-    err = SQLError.create_pdbc(dbc.dbc)
-    try
-      h.assert_eq[String val]("08001", err.get_tuples()(0)?._2)
-    else
-      h.fail("SQLError contents not found: " + err.string())
-    end
+    h.assert_eq[String val]("08001", (dbc.get_err() as SQLError val).latest_sqlstate())
+    h.assert_eq[USize](1, (dbc.get_err() as SQLError val).sqlstates().size())
 
     // Unknown Postgresql User
     h.assert_false(dbc.connect("psqlred_baduser"))
     h.assert_eq[String]("SQLError", dbc.get_err().string())
-
-    err = SQLError.create_pdbc(dbc.dbc)
-    try
-      h.assert_eq[String val]("08001", err.get_tuples()(0)?._2)
-    else
-      h.fail("SQLError contents not found: " + err.string())
-    end
+    h.assert_eq[String val]("08001", (dbc.get_err() as SQLError val).latest_sqlstate())
+    h.assert_eq[USize](1, (dbc.get_err() as SQLError val).sqlstates().size())
 
     // Unknown Postgresql Database
     h.assert_false(dbc.connect("psqlred_baddatabase"))
     h.assert_eq[String]("SQLError", dbc.get_err().string())
-
-    err = SQLError.create_pdbc(dbc.dbc)
-    try
-      h.assert_eq[String val]("08001", err.get_tuples()(0)?._2)
-    else
-      h.fail("SQLError contents not found: " + err.string())
-    end
+    h.assert_eq[String val]("08001", (dbc.get_err() as SQLError val).latest_sqlstate())
+    h.assert_eq[USize](1, (dbc.get_err() as SQLError val).sqlstates().size())
 
     // Unknown MariaDB User
     h.assert_false(dbc.connect("mariadb_baduser"))
     h.assert_eq[String]("SQLError", dbc.get_err().string())
-
-    err = SQLError.create_pdbc(dbc.dbc)
-    try
-      h.assert_eq[String val]("28000", err.get_tuples()(0)?._2)
-    else
-      h.fail("SQLError contents not found: " + err.string())
-    end
+    h.assert_eq[String val]("28000", (dbc.get_err() as SQLError val).latest_sqlstate())
+    h.assert_eq[USize](1, (dbc.get_err() as SQLError val).sqlstates().size())
 
     // Unknown MariaDB database
     h.assert_false(dbc.connect("mariadb_baddatabase"))
     h.assert_eq[String]("SQLError", dbc.get_err().string())
-
-    err = SQLError.create_pdbc(dbc.dbc)
-    try
-      h.assert_eq[String val]("42000", err.get_tuples()(0)?._2)
-    else
-      h.fail("SQLError contents not found: " + err.string())
-    end
+    h.assert_eq[String val]("42000", (dbc.get_err() as SQLError val).latest_sqlstate())
+    h.assert_eq[USize](1, (dbc.get_err() as SQLError val).sqlstates().size())
 

--- a/pony-odbc/tests/stmt_api.pony
+++ b/pony-odbc/tests/stmt_api.pony
@@ -17,13 +17,11 @@ class \nodoc\ iso _TestStmtAPI is UnitTest
     var dbc: ODBCDbc = ODBCDbc(ODBCEnv.>set_odbc3())
 
     h.assert_true(dbc.connect(dsn))
-    h.assert_eq[String]("SQLSuccess", dbc.get_err().string())
 
     create_temp_table(h, dbc)
     populate_temp_table(h, dbc)
     query_test_rowcounts(h, dbc)
     query_test_under_allocation(h, dbc)
-
 
   fun create_temp_table(h: TestHelper, dbc: ODBCDbc) =>
     var stm: ODBCStmt = ODBCStmt(dbc)
@@ -32,12 +30,8 @@ class \nodoc\ iso _TestStmtAPI is UnitTest
       .>prepare("create temporary table odbthingtest (i integer, s varchar(100))")?
       .>execute()?
     else
-      Debug.out("Something in there failed")
-      try
-        for f in (stm.get_err() as SQLError val).get_records().values() do
-          h.fail(f)
-        end
-      end
+      Debug.out("create_temp_table(): " + stm.errtext)
+      h.fail(stm.errtext)
     end
 
   fun populate_temp_table(h: TestHelper, dbc: ODBCDbc) =>
@@ -55,11 +49,8 @@ class \nodoc\ iso _TestStmtAPI is UnitTest
         stm.execute()?
       end
     else
-      try
-        for f in (stm.get_err() as SQLError val).get_records().values() do
-          h.fail(f)
-        end
-      end
+      Debug.out("populate_temp_table(): " + stm.errtext)
+      h.fail(stm.errtext)
     end
 
   fun query_test_rowcounts(h: TestHelper, dbc: ODBCDbc) =>
@@ -92,13 +83,8 @@ class \nodoc\ iso _TestStmtAPI is UnitTest
       end
       stm.finish()?
     else
-      try
-        for f in (stm.get_err() as SQLError val).get_records().values() do
-          h.fail(f)
-        end
-      else
-        Debug.out("Got err as: " + stm.get_err().string())
-      end
+      Debug.out("query_test_rowcounts(): " + stm.errtext)
+      h.fail(stm.errtext)
     end
 
   fun query_test_under_allocation(h: TestHelper, dbc: ODBCDbc) =>
@@ -126,18 +112,10 @@ class \nodoc\ iso _TestStmtAPI is UnitTest
         end
         stm.finish()?
       else
-        try
-          for f in (stm.get_err() as SQLSuccessWithInfo val).get_records().values() do
-            h.fail(f)
-          end
-        end
+      Debug.out("query_test_under_allocation(): " + stm.errtext)
+        h.fail(stm.errtext)
       end
     else
-      try
-        for f in (stm.get_err() as SQLError val).get_records().values() do
-          h.fail(f)
-        end
-      else
-        Debug.out("Got err as: " + stm.get_err().string())
-      end
+      Debug.out("query_test_under_allocation() the second: " + stm.errtext)
+      h.fail(stm.errtext)
     end

--- a/pony-odbc/tests/transactions.pony
+++ b/pony-odbc/tests/transactions.pony
@@ -20,16 +20,11 @@ class \nodoc\ iso _TestTransactions is UnitTest
     h.assert_eq[String]("SQLSuccess", dbc.get_err().string())
 
     h.assert_true(dbc.get_autocommit()?)
-    showerr(dbc.get_err())
     dbc.set_autocommit(false)
-    showerr(dbc.get_err())
     h.assert_false(dbc.get_autocommit()?)
-    showerr(dbc.get_err())
     dbc.set_autocommit(true)
-    showerr(dbc.get_err())
     h.assert_true(dbc.get_autocommit()?)
     dbc.set_autocommit(false)
-    showerr(dbc.get_err())
     h.assert_false(dbc.get_autocommit()?)
 
     create_temp_table(h, dbc)
@@ -48,12 +43,7 @@ class \nodoc\ iso _TestTransactions is UnitTest
       .>prepare("create temporary table transactiontest (i integer, s varchar(100))")?
       .>execute()?
     else
-      Debug.out("Something in there failed")
-      try
-        for f in (stm.get_err() as SQLError val).get_records().values() do
-          h.fail(f)
-        end
-      end
+      h.fail(stm.errtext)
     end
 
   fun populate_temp_table(h: TestHelper, dbc: ODBCDbc) =>
@@ -71,11 +61,7 @@ class \nodoc\ iso _TestTransactions is UnitTest
         stm.execute()?
       end
     else
-      try
-        for f in (stm.get_err() as SQLError val).get_records().values() do
-          h.fail(f)
-        end
-      end
+      h.fail(stm.errtext)
     end
 
   fun query_test_rowcounts(h: TestHelper, dbc: ODBCDbc) =>
@@ -108,13 +94,7 @@ class \nodoc\ iso _TestTransactions is UnitTest
       end
       stm.finish()?
     else
-      try
-        for f in (stm.get_err() as SQLError val).get_records().values() do
-          h.fail(f)
-        end
-      else
-        Debug.out("Got err as: " + stm.get_err().string())
-      end
+      h.fail(stm.errtext)
     end
 
   fun query_test_under_allocation(h: TestHelper, dbc: ODBCDbc) =>
@@ -142,23 +122,9 @@ class \nodoc\ iso _TestTransactions is UnitTest
         end
         stm.finish()?
       else
-        try
-          for f in (stm.get_err() as SQLSuccessWithInfo val).get_records().values() do
-            h.fail(f)
-          end
-        end
+        h.fail(stm.errtext)
       end
     else
-      try
-        for f in (stm.get_err() as SQLError val).get_records().values() do
-          h.fail(f)
-        end
-      else
-        Debug.out("Got err as: " + stm.get_err().string())
-      end
+      h.fail(stm.errtext)
     end
 
-  fun showerr(r: SQLReturn val) =>
-    match r
-    | let x: SQLError val => Debug.out(x.get_err_strings())
-    end

--- a/pony-odbc/tests/type_tests.pony
+++ b/pony-odbc/tests/type_tests.pony
@@ -52,12 +52,7 @@ class \nodoc\ iso _TestTypeTests is UnitTest
         .>execute()?
       end
     else
-      Debug.out("Something in there failed")
-      try
-        for f in (stm.get_err() as SQLError val).get_records().values() do
-          h.fail(f)
-        end
-      end
+      h.fail(stm.errtext)
     end
 
   fun populate_temp_table(h: TestHelper, dbc: ODBCDbc) =>
@@ -85,11 +80,7 @@ class \nodoc\ iso _TestTypeTests is UnitTest
         stm.execute()?
       end
     else
-      try
-        for f in (stm.get_err() as SQLError val).get_records().values() do
-          h.fail(f)
-        end
-      end
+      h.fail(stm.errtext)
     end
 
   fun query_test_rowcounts(h: TestHelper, dbc: ODBCDbc) =>
@@ -127,13 +118,7 @@ class \nodoc\ iso _TestTypeTests is UnitTest
       end
       stm.finish()?
     else
-      try
-        for f in (stm.get_err() as SQLError val).get_records().values() do
-          h.fail(f)
-        end
-      else
-        Debug.out("Got err as: " + stm.get_err().string())
-      end
+      h.fail(stm.errtext)
     end
 
   fun query_test_under_allocation(h: TestHelper, dbc: ODBCDbc) =>
@@ -165,26 +150,12 @@ class \nodoc\ iso _TestTypeTests is UnitTest
           h.assert_eq[F32]((cntr.f32()+0.5), poutb._4.read()?)
           h.assert_eq[F64]((cntr.f64()+0.5), poutb._5.read()?)
           h.assert_eq[String](cntr.string(), poutb._6.read())
-//          h.assert_eq[USize](6, poutb._7.read().size())
-//          h.assert_eq[I32](cntr, poutb._7.read()?)
           cntr = cntr + 1
-//        pina._4.write((f.f32() * 0.332).f32())
-//        pina._5.write((f.f64() * 0.00332).f64())
         end
         stm.finish()?
       else
-        try
-          for f in (stm.get_err() as SQLSuccessWithInfo val).get_records().values() do
-            h.fail(f)
-          end
-        end
+        h.fail(stm.errtext)
       end
     else
-      try
-        for f in (stm.get_err() as SQLError val).get_records().values() do
-          h.fail(f)
-        end
-      else
-        Debug.out("Got err as: " + stm.get_err().string())
-      end
+      h.fail(stm.errtext)
     end


### PR DESCRIPTION
* Removed the \nodoc\ tag from SQLError and SQLSuccessWithInfo. They shouldn't be needed by end-users, but there may be some edge-cases where it is.
* Moved fields to private
* Moved create_p* to nodoc as they shouldn't be used by end-users.
* Added latest_sqlstate(), sqlstates() for ease of decision making.
* Changed all the tests to use stm.errtext instead of generating their own copy of SQLError.