### PR TITLE
Misc bugfixes for differences in mariadb behaviour across versions:

### DIFF
--- a/.release-notes/32.md
+++ b/.release-notes/32.md
@@ -1,0 +1,12 @@
+## Misc bugfixes specific to mariadb.
+
+Differences in versions required the following changes:
+
+* SQLExecute execution returns SQLSuccess in newer versions instead of
+  SQLSuccessWithInfo. We now need to validate the buffers for every both
+  SQLSucess and SQLSuccessWithInfo.
+* When providing syntactically invalid SQL to SQLPrepare, newer versions
+  throw a SQLError on SQLPrepare, older versions on the SQLExecute (like
+  all other tested connectors).
+* ODBCDbc will no longer apply SQL\_AUTOCOMMIT after a connection is made
+  in more recent versions.

--- a/pony-odbc/odbc_stmt.pony
+++ b/pony-odbc/odbc_stmt.pony
@@ -240,8 +240,9 @@ class ODBCStmt is SqlState
     """
     _call_location = sl
     _err = ODBCStmtFFI.fetch_scroll(_sth, d, offset)
+
     match _err
-    | let x: SQLSuccess val => true
+    | let x: SQLSuccess val => _check_and_expand_column_buffers()?; true
     | let x: SQLSuccessWithInfo val => _check_and_expand_column_buffers()?; true
     | let x: SQLNoData val => false
     else

--- a/pony-odbc/odbc_stmt_ffi.pony
+++ b/pony-odbc/odbc_stmt_ffi.pony
@@ -265,7 +265,6 @@ primitive \nodoc\ ODBCStmtFFI
       v.ptr,
       v.alloc_size.i64(),
       v.written_size)
-//use @SQLBindCol[I16](StatementHandle: Pointer[None] tag, ColumnNumber: U16, TargetType: I16, TargetValue: Pointer[U8] tag, BufferLength: I64, StrLenorInd: Pointer[I64] tag)
 
     match rv
     | 0 => return SQLSuccess

--- a/pony-odbc/sql_type.pony
+++ b/pony-odbc/sql_type.pony
@@ -1,3 +1,5 @@
+use "debug"
+
 trait SQLType
   """
   The most portable implementation of ODBC when reading and writing across

--- a/pony-odbc/tests/_test.pony
+++ b/pony-odbc/tests/_test.pony
@@ -34,4 +34,3 @@ actor \nodoc\ Main is TestList
     test(_TestTransactions("psqlred"))
     test(_TestTransactions("mariadb"))
     test(_TestTransactions("sqlitedb3"))
-

--- a/pony-odbc/tests/transactions.pony
+++ b/pony-odbc/tests/transactions.pony
@@ -16,8 +16,6 @@ class \nodoc\ iso _TestTransactions is UnitTest
       env.set_odbc3()?
       var dbc: ODBCDbc = env.dbc()?
 
-      h.assert_true(dbc.connect(dsn)?)
-      h.assert_eq[String]("SQLSuccess", dbc.get_err().string())
 
       h.assert_true(dbc.get_autocommit()?)
       dbc.set_autocommit(false)?
@@ -26,6 +24,9 @@ class \nodoc\ iso _TestTransactions is UnitTest
       h.assert_true(dbc.get_autocommit()?)
       dbc.set_autocommit(false)?
       h.assert_false(dbc.get_autocommit()?)
+
+      h.assert_true(dbc.connect(dsn)?)
+      h.assert_eq[String]("SQLSuccess", dbc.get_err().string())
 
       create_temp_table(h, dbc)
       h.assert_true(dbc.commit()?)


### PR DESCRIPTION
Differences in versions required the following changes:

* SQLExecute execution returns SQLSuccess in newer versions instead of SQLSuccessWithInfo. We now need to validate the buffers for every both SQLSucess and SQLSuccessWithInfo.
* When providing syntactically invalid SQL to SQLPrepare, newer versions throw a SQLError on SQLPrepare, older versions on the SQLExecute (like all other tested connectors).
* ODBCDbc will no longer apply SQL_AUTOCOMMIT after a connection is made in more recent versions.