### PR TITLE
Makes SQLError and SQLSuccessWithInfo primitives

### DIFF
--- a/pony-odbc/ffi/f.pony
+++ b/pony-odbc/ffi/f.pony
@@ -2751,3 +2751,15 @@ The following table lists ODBC functions, grouped by type of task, and includes 
   fun pSQLDriversA(phenv: Pointer[None] tag, pfDirection: U16, pszDriverDesc: String, pcbDriverDescMax: I16, ppcbDriverDesc: CBoxedI16, pszDriverAttributes: String, pcbDrvrAttrMax: I16, ppcbDrvrAttr: CBoxedI16): I16 =>
     @SQLDriversA(phenv, pfDirection, pszDriverDesc.cstring(), pcbDriverDescMax, ppcbDriverDesc, pszDriverAttributes.cstring(), pcbDrvrAttrMax, ppcbDrvrAttr)
 
+  fun resolve(rv: I16): SQLReturn val =>
+    match rv
+    | 0 => return SQLSuccess
+    | 1 => return SQLSuccessWithInfo
+    | 2 => return SQLStillExecuting
+    | -1 => return SQLError
+    | -2 => return SQLInvalidHandle
+    | 99 => return SQLNeedData
+    | 100 => return SQLNoData
+    end
+    recover val PonyDriverError("ODBCHandleStmt.result_count() get invalid return code: " + rv.string()) end
+

--- a/pony-odbc/odbc_dbc.pony
+++ b/pony-odbc/odbc_dbc.pony
@@ -31,7 +31,7 @@ class ODBCDbc is SqlState
   """
   let dbc: ODBCHandleDbc tag
   let _henv: ODBCHandleEnv tag
-  var _err: _SQLReturn val = SQLSuccess
+  var _err: SQLReturn val = SQLSuccess
   var strict: Bool = true
 
   var _call_location: SourceLoc val = __loc
@@ -67,7 +67,7 @@ class ODBCDbc is SqlState
     end
     _check_valid()?
 
-//  fun ref get_info(i: _SQLInfoTypes, sl: SourceLoc val = __loc): (_SQLReturn val, String val) =>
+//  fun ref get_info(i: _SQLInfoTypes, sl: SourceLoc val = __loc): (SQLReturn val, String val) =>
 //    _call_location = sl
 //    ODBCDbcFFI.get_info(dbc, i)
 
@@ -131,4 +131,4 @@ class ODBCDbc is SqlState
     ODBCDbcFFI.free(dbc)
 
   // Present only for introspection during tests
-  fun \nodoc\ get_err(): _SQLReturn val => _err
+  fun \nodoc\ get_err(): SQLReturn val => _err

--- a/pony-odbc/odbc_dbc_ffi.pony
+++ b/pony-odbc/odbc_dbc_ffi.pony
@@ -21,9 +21,9 @@ primitive \nodoc\ ODBCDbcFFI
     var rv: I16 = @SQLEndTran(2, NullablePointer[ODBCHandleDbc tag](h), 0)
     match rv
     | 0 => return SQLSuccess
-    | 1 => return recover val SQLSuccessWithInfo.create_pdbc(h) end
+    | 1 => return SQLSuccessWithInfo
     | 2 => return SQLStillExecuting
-    | -1 => return recover val SQLError.create_pdbc(h) end
+    | -1 => return SQLError
     | -2 => return SQLInvalidHandle
     else
       return recover val PonyDriverError("ODBCFFI.commit() got invalid return code: " + rv.string()) end
@@ -33,9 +33,9 @@ primitive \nodoc\ ODBCDbcFFI
     var rv: I16 = @SQLEndTran(2, NullablePointer[ODBCHandleDbc tag](h), 1)
     match rv
     | 0 => return SQLSuccess
-    | 1 => return recover val SQLSuccessWithInfo.create_pdbc(h) end
+    | 1 => return SQLSuccessWithInfo
     | 2 => return SQLStillExecuting
-    | -1 => return recover val SQLError.create_pdbc(h) end
+    | -1 => return SQLError
     | -2 => return SQLInvalidHandle
     else
       return recover val PonyDriverError("ODBCFFI.commit() got invalid return code: " + rv.string()) end
@@ -50,8 +50,8 @@ primitive \nodoc\ ODBCDbcFFI
                               Pointer[I16])
     match rv
     | 0 => return (SQLSuccess, buffer.string())
-    | 1 => return (recover val SQLSuccessWithInfo.create_pdbc(h) end, "")
-    | -1 => return (recover val SQLError.create_pdbc(h) end, "")
+    | 1 => return (SQLSuccessWithInfo, "")
+    | -1 => return (SQLError, "")
     | -2 => return (SQLInvalidHandle, "")
     else
       return (recover val PonyDriverError("ODBCFFI.get_info() got invalid return code: " + rv.string()) end, "")
@@ -66,7 +66,7 @@ primitive \nodoc\ ODBCDbcFFI
                                      Pointer[I32])
     match rv
     | 0 => return (SQLSuccess, value)
-    | -1 => return (recover val SQLError.create_pdbc(h) end, value)
+    | -1 => return (SQLError, value)
     | -2 => return (SQLInvalidHandle, value)
     else
       (recover val PonyDriverError("ODBCFFI.get_attr() got invalid return code: " + rv.string()) end, value)
@@ -76,7 +76,7 @@ primitive \nodoc\ ODBCDbcFFI
     var rv: I16 = @SQLSetConnectAttr[I16](NullablePointer[ODBCHandleDbc tag](h), attrib(), value', I32(0))
     match rv
     | 0 => return SQLSuccess
-    | -1 => return recover val SQLError.create_pdbc(h) end
+    | -1 => return SQLError
     | -2 => return SQLInvalidHandle
     else
       recover val PonyDriverError("ODBCFFI.set_attr_i32() got invalid return code: " + rv.string()) end
@@ -90,7 +90,7 @@ primitive \nodoc\ ODBCDbcFFI
     var rv: I16 = @SQLSetConnectAttr[I16](NullablePointer[ODBCHandleDbc tag](h), _SQLAttrApplicationName(), s.cstring(), s.size().i32())
     match rv
     | 0 => return SQLSuccess
-    | -1 => return recover val SQLError.create_pdbc(h) end
+    | -1 => return SQLError
     | -2 => return SQLInvalidHandle
     else
       recover val PonyDriverError("ODBCFFI.set_application_name() got invalid return code: " + rv.string()) end
@@ -103,8 +103,8 @@ primitive \nodoc\ ODBCDbcFFI
     var rv: I16 = @SQLConnect(NullablePointer[ODBCHandleDbc tag](h), dsn.cstring(), dsn.size().i16(), "".cstring(), 0, "".cstring(), 0)
     match rv
     | 0 => return SQLSuccess
-    | 1 => return recover val SQLSuccessWithInfo.create_pdbc(h) end
-    | -1 => return recover val SQLError.create_pdbc(h) end
+    | 1 => return SQLSuccessWithInfo
+    | -1 => return SQLError
     | -2 => return SQLInvalidHandle
     else
       recover val PonyDriverError("ODBCFFI.connect() got invalid return code: " + rv.string()) end
@@ -115,8 +115,8 @@ primitive \nodoc\ ODBCDbcFFI
     var rvv: I16 = @SQLAllocHandle(2, NullablePointer[ODBCHandleEnv tag](h), addressof rv)
     match rvv
     | 0 => return (SQLSuccess, rv)
-    | 1 => return (recover val SQLSuccessWithInfo.create_pdbc(rv) end, rv)
-    | -1 => return (recover val SQLError.create_pdbc(rv) end, rv)
+    | 1 => return (SQLSuccessWithInfo, rv)
+    | -1 => return (SQLError, rv)
     | -2 => return (SQLInvalidHandle, rv)
     else
       (recover val PonyDriverError("ODBCFFI.sql_alloc_handle() got invalid return code: " + rvv.string()) end, rv)
@@ -126,9 +126,9 @@ primitive \nodoc\ ODBCDbcFFI
     var rv: I16 = @SQLDisconnect(NullablePointer[ODBCHandleDbc tag](h))
     match rv
     | 0 => return SQLSuccess
-    | 1 => return recover val SQLSuccessWithInfo.create_pdbc(h) end
+    | 1 => return SQLSuccessWithInfo
     | 2 => return SQLStillExecuting
-    | -1 => return recover val SQLError.create_pdbc(h) end
+    | -1 => return SQLError
     | -2 => return SQLInvalidHandle
     else
       recover val PonyDriverError("ODBCFFI.disconnect() got invalid return code: " + rv.string()) end

--- a/pony-odbc/odbc_dbc_ffi.pony
+++ b/pony-odbc/odbc_dbc_ffi.pony
@@ -10,14 +10,14 @@ use "debug"
 struct \nodoc\ ODBCHandleDbc
 
 primitive \nodoc\ ODBCDbcFFI
-  fun alloc(h: ODBCHandleEnv tag): (_SQLReturn val, ODBCHandleDbc tag) =>
+  fun alloc(h: ODBCHandleEnv tag): (SQLReturn val, ODBCHandleDbc tag) =>
     """
     Returns an ODBCHandleEnv, used by the ODBC FFI calls to represent a
     database connection.
     """
     ODBCDbcFFI.sql_alloc_handle(h)
 
-  fun commit(h: ODBCHandleDbc tag): _SQLReturn val =>
+  fun commit(h: ODBCHandleDbc tag): SQLReturn val =>
     var rv: I16 = @SQLEndTran(2, NullablePointer[ODBCHandleDbc tag](h), 0)
     match rv
     | 0 => return SQLSuccess
@@ -29,7 +29,7 @@ primitive \nodoc\ ODBCDbcFFI
       return recover val PonyDriverError("ODBCFFI.commit() got invalid return code: " + rv.string()) end
     end
 
-  fun rollback(h: ODBCHandleDbc tag): _SQLReturn val =>
+  fun rollback(h: ODBCHandleDbc tag): SQLReturn val =>
     var rv: I16 = @SQLEndTran(2, NullablePointer[ODBCHandleDbc tag](h), 1)
     match rv
     | 0 => return SQLSuccess
@@ -41,7 +41,7 @@ primitive \nodoc\ ODBCDbcFFI
       return recover val PonyDriverError("ODBCFFI.commit() got invalid return code: " + rv.string()) end
     end
 
-  fun get_info(h: ODBCHandleDbc tag, infotype: _SQLInfoTypes): (_SQLReturn val, String val) =>
+  fun get_info(h: ODBCHandleDbc tag, infotype: _SQLInfoTypes): (SQLReturn val, String val) =>
     var buffer: CBoxedArray = CBoxedArray.>alloc(4096)
     var rv: I16 = @SQLGetInfo(NullablePointer[ODBCHandleDbc tag](h),
                               infotype(),
@@ -57,7 +57,7 @@ primitive \nodoc\ ODBCDbcFFI
       return (recover val PonyDriverError("ODBCFFI.get_info() got invalid return code: " + rv.string()) end, "")
     end
 
-  fun get_attr_i32(h: ODBCHandleDbc tag, attrib: _SqlDbcAttrI32): (_SQLReturn val, I32) =>
+  fun get_attr_i32(h: ODBCHandleDbc tag, attrib: _SqlDbcAttrI32): (SQLReturn val, I32) =>
     var value: I32 = 76
     var rv: I16 = @SQLGetConnectAttr(NullablePointer[ODBCHandleDbc tag](h),
                                      attrib(),
@@ -72,7 +72,7 @@ primitive \nodoc\ ODBCDbcFFI
       (recover val PonyDriverError("ODBCFFI.get_attr() got invalid return code: " + rv.string()) end, value)
     end
 
-  fun set_attr_i32(h: ODBCHandleDbc tag, attrib: _SqlDbcAttrI32, value': I32): _SQLReturn val =>
+  fun set_attr_i32(h: ODBCHandleDbc tag, attrib: _SqlDbcAttrI32, value': I32): SQLReturn val =>
     var rv: I16 = @SQLSetConnectAttr[I16](NullablePointer[ODBCHandleDbc tag](h), attrib(), value', I32(0))
     match rv
     | 0 => return SQLSuccess
@@ -82,7 +82,7 @@ primitive \nodoc\ ODBCDbcFFI
       recover val PonyDriverError("ODBCFFI.set_attr_i32() got invalid return code: " + rv.string()) end
     end
 
-  fun set_application_name(h: ODBCHandleDbc tag, s: String val): _SQLReturn val =>
+  fun set_application_name(h: ODBCHandleDbc tag, s: String val): SQLReturn val =>
     """
     Tells the ODBC driver your application name.  I'm not sure if it passes
     it to the database for all database drivers.
@@ -96,7 +96,7 @@ primitive \nodoc\ ODBCDbcFFI
       recover val PonyDriverError("ODBCFFI.set_application_name() got invalid return code: " + rv.string()) end
     end
 
-  fun connect(h: ODBCHandleDbc tag, dsn: String val): _SQLReturn val =>
+  fun connect(h: ODBCHandleDbc tag, dsn: String val): SQLReturn val =>
     """
     Opens the connection to the database on the provided DSN.
     """
@@ -110,7 +110,7 @@ primitive \nodoc\ ODBCDbcFFI
       recover val PonyDriverError("ODBCFFI.connect() got invalid return code: " + rv.string()) end
     end
 
-  fun sql_alloc_handle(h: ODBCHandleEnv tag): (_SQLReturn val, ODBCHandleDbc tag) =>
+  fun sql_alloc_handle(h: ODBCHandleEnv tag): (SQLReturn val, ODBCHandleDbc tag) =>
     var rv: ODBCHandleDbc tag = ODBCHandleDbc
     var rvv: I16 = @SQLAllocHandle(2, NullablePointer[ODBCHandleEnv tag](h), addressof rv)
     match rvv
@@ -122,7 +122,7 @@ primitive \nodoc\ ODBCDbcFFI
       (recover val PonyDriverError("ODBCFFI.sql_alloc_handle() got invalid return code: " + rvv.string()) end, rv)
     end
 
-  fun disconnect(h: ODBCHandleDbc tag): _SQLReturn val =>
+  fun disconnect(h: ODBCHandleDbc tag): SQLReturn val =>
     var rv: I16 = @SQLDisconnect(NullablePointer[ODBCHandleDbc tag](h))
     match rv
     | 0 => return SQLSuccess

--- a/pony-odbc/odbc_env.pony
+++ b/pony-odbc/odbc_env.pony
@@ -21,7 +21,7 @@ class ODBCEnv is SqlState
   """
   let odbcenv: ODBCHandleEnv tag
   var strict: Bool = true
-  var _err: _SQLReturn val = SQLSuccess
+  var _err: SQLReturn val = SQLSuccess
 
   new create() => None
     """

--- a/pony-odbc/odbc_env_ffi.pony
+++ b/pony-odbc/odbc_env_ffi.pony
@@ -16,7 +16,7 @@ primitive \nodoc\ ODBCEnvFFI
 |SQL_ATTR_OUTPUT_NTS (ODBC 3.0)|A 32-bit integer that determines how the driver returns string data. If SQL_TRUE, the driver returns string data null-terminated. If SQL_FALSE, the driver does not return string data null-terminated.<br /><br /> This attribute defaults to SQL_TRUE. A call to **SQLSetEnvAttr** to set it to SQL_TRUE returns SQL_SUCCESS. A call to **SQLSetEnvAttr** to set it to SQL_FALSE returns SQL_ERROR and SQLSTATE HYC00 (Optional feature not implemented).|
 """
 
-  fun get_env_attr(h: ODBCHandleEnv tag, a: _SqlEnvAttr, v: CBoxedI32): _SQLReturn val =>
+  fun get_env_attr(h: ODBCHandleEnv tag, a: _SqlEnvAttr, v: CBoxedI32): SQLReturn val =>
     var rv: I16 = @SQLGetEnvAttr(NullablePointer[ODBCHandleEnv tag](h), a(), v, 0, Pointer[I32])
     match rv
     | 0  => return SQLSuccess
@@ -27,7 +27,7 @@ primitive \nodoc\ ODBCEnvFFI
       recover val PonyDriverError("ODBCEnvFFI.get_env_attr() got invalid return code: " + rv.string()) end
     end
 
-  fun set_odbc2(h: ODBCHandleEnv tag): _SQLReturn val =>
+  fun set_odbc2(h: ODBCHandleEnv tag): SQLReturn val =>
     """
     Sets the Environment to version ODBC2.  I should probably remove this
     since I've not implemented any of those functionsi (yet).
@@ -42,7 +42,7 @@ primitive \nodoc\ ODBCEnvFFI
       recover val PonyDriverError("ODBCEnvFFI.set_odbc2() got invalid return code: " + rv.string()) end
     end
 
-  fun set_odbc3(h: ODBCHandleEnv tag): _SQLReturn val =>
+  fun set_odbc3(h: ODBCHandleEnv tag): SQLReturn val =>
     """
     Sets the Environment to version ODBC3.  You should always call
     this, since version 3 is the only one implemented thus far.

--- a/pony-odbc/odbc_env_ffi.pony
+++ b/pony-odbc/odbc_env_ffi.pony
@@ -16,28 +16,12 @@ primitive \nodoc\ ODBCEnvFFI
 |SQL_ATTR_OUTPUT_NTS (ODBC 3.0)|A 32-bit integer that determines how the driver returns string data. If SQL_TRUE, the driver returns string data null-terminated. If SQL_FALSE, the driver does not return string data null-terminated.<br /><br /> This attribute defaults to SQL_TRUE. A call to **SQLSetEnvAttr** to set it to SQL_TRUE returns SQL_SUCCESS. A call to **SQLSetEnvAttr** to set it to SQL_FALSE returns SQL_ERROR and SQLSTATE HYC00 (Optional feature not implemented).|
 """
 
-  fun alloc(): (_SQLReturn val, ODBCHandleEnv tag) =>
-    """
-    Returns an ODBCHandleEnv, used by the ODBC FFI calls to represent
-    your environment.
-    """
-    var rv: ODBCHandleEnv tag = ODBCHandleEnv
-    var rvv: I16 = @SQLAllocHandle(1, Pointer[None], addressof rv)
-    match rvv
-    | 0 => return (SQLSuccess, rv)
-    | 1 => return (recover val SQLSuccessWithInfo.create_penv(rv) end, rv)
-    | -1 => return (recover val SQLError.create_penv(rv) end, rv)
-    | -2 => return (SQLInvalidHandle, rv)
-    else
-      (recover val PonyDriverError("ODBCEnvFFI.set_odbc2() got invalid return code: " + rvv.string()) end, rv)
-    end
-
   fun get_env_attr(h: ODBCHandleEnv tag, a: _SqlEnvAttr, v: CBoxedI32): _SQLReturn val =>
     var rv: I16 = @SQLGetEnvAttr(NullablePointer[ODBCHandleEnv tag](h), a(), v, 0, Pointer[I32])
     match rv
     | 0  => return SQLSuccess
-    | 1  => return recover val SQLSuccessWithInfo.create_penv(h) end
-    | -1 => return recover val SQLError.create_penv(h) end
+    | 1  => return SQLSuccessWithInfo
+    | -1 => return SQLError
     | -2 => return SQLInvalidHandle
     else
       recover val PonyDriverError("ODBCEnvFFI.get_env_attr() got invalid return code: " + rv.string()) end
@@ -51,8 +35,8 @@ primitive \nodoc\ ODBCEnvFFI
     var rv: I16 = @SQLSetEnvAttr(NullablePointer[ODBCHandleEnv tag](h), _SqlAttrODBCVersion(), _SqlODBC2(), _SQLIsInteger())
     match rv
     | 0 => return SQLSuccess
-    | 1 => return recover val SQLSuccessWithInfo.create_penv(h) end
-    | -1 => return recover val SQLError.create_penv(h) end
+    | 1 => return SQLSuccessWithInfo
+    | -1 => return SQLError
     | -2 => return SQLInvalidHandle
     else
       recover val PonyDriverError("ODBCEnvFFI.set_odbc2() got invalid return code: " + rv.string()) end
@@ -66,8 +50,8 @@ primitive \nodoc\ ODBCEnvFFI
     var rv: I16 = @SQLSetEnvAttr(NullablePointer[ODBCHandleEnv tag](h), _SqlAttrODBCVersion(), _SqlODBC3(), _SQLIsInteger())
     match rv
     | 0 => return SQLSuccess
-    | 1 => return recover val SQLSuccessWithInfo.create_penv(h) end
-    | -1 => return recover val SQLError.create_penv(h) end
+    | 1 => return SQLSuccessWithInfo
+    | -1 => return SQLError
     | -2 => return SQLInvalidHandle
     else
       recover val PonyDriverError("ODBCEnvFFI.set_odbc3() got invalid return code: " + rv.string()) end

--- a/pony-odbc/odbc_stmt.pony
+++ b/pony-odbc/odbc_stmt.pony
@@ -128,7 +128,7 @@ class ODBCStmt is SqlState
   var _env: ODBCHandleEnv tag
   var _dbh: ODBCHandleDbc tag
   var _sth: ODBCHandleStmt tag
-  var _err: _SQLReturn val
+  var _err: SQLReturn val
   var _parameters: Array[SQLType] = Array[SQLType]
   var _columns:    Array[SQLType] = Array[SQLType]
   var strict: Bool = true
@@ -273,7 +273,7 @@ class ODBCStmt is SqlState
     end
 
   // Used to do introspection during testing
-  fun \nodoc\ get_err(): _SQLReturn val => _err
+  fun \nodoc\ get_err(): SQLReturn val => _err
 
   fun \nodoc\ ref _check_valid(): Bool ? =>
     if strict then

--- a/pony-odbc/odbc_stmt_ffi.pony
+++ b/pony-odbc/odbc_stmt_ffi.pony
@@ -22,8 +22,8 @@ primitive \nodoc\ ODBCStmtFFI
     var rvv: I16 = @SQLAllocHandle(3, NullablePointer[ODBCHandleDbc tag](h), addressof rv)
     match rvv
     | 0 => return (SQLSuccess, rv)
-    | 1 => return (recover val SQLSuccessWithInfo.create_pstmt(rv) end, rv)
-    | -1 => return (recover val SQLError.create_pstmt(rv) end, rv)
+    | 1 => return (SQLSuccessWithInfo, rv)
+    | -1 => return (SQLError, rv)
     | -2 => return (SQLInvalidHandle, rv)
     else
       (recover val PonyDriverError("ODBCStmtFFI.alloc() got invalid return code: " + rvv.string()) end, rv)
@@ -40,10 +40,10 @@ primitive \nodoc\ ODBCStmtFFI
 
     match rv
     | 0 => return SQLSuccess
-    | 1 => return recover val SQLSuccessWithInfo.create_pstmt(h) end
+    | 1 => return SQLSuccessWithInfo
     | 100 => return SQLNoData
     | 2 => return SQLStillExecuting
-    | -1 => return recover val SQLError.create_pstmt(h) end
+    | -1 => return SQLError
     | -2 => return SQLInvalidHandle
     else
       recover val PonyDriverError("ODBCEnvFFI.fetch_scroll() got invalid return code: " + rv.string()) end
@@ -56,10 +56,10 @@ primitive \nodoc\ ODBCStmtFFI
     var rv: I16 = @SQLFetchScroll(NullablePointer[ODBCHandleStmt tag](h), d(), offset)
     match rv
     | 0 => return SQLSuccess
-    | 1 => return recover val SQLSuccessWithInfo.create_pstmt(h) end
+    | 1 => return SQLSuccessWithInfo
     | 100 => return SQLNoData
     | 2 => return SQLStillExecuting
-    | -1 => return recover val SQLError.create_pstmt(h) end
+    | -1 => return SQLError
     | -2 => return SQLInvalidHandle
     else
       recover val PonyDriverError("ODBCEnvFFI.fetch_scroll() got invalid return code: " + rv.string()) end
@@ -72,9 +72,9 @@ primitive \nodoc\ ODBCStmtFFI
     var rv: I16 = @SQLPrepare(NullablePointer[ODBCHandleStmt tag](h), str.cstring(), str.size().i32())
     match rv
     | 0 => return SQLSuccess
-    | 1 => return recover val SQLSuccessWithInfo.create_pstmt(h) end
+    | 1 => return SQLSuccessWithInfo
     | 2 => return SQLStillExecuting
-    | -1 => return recover val SQLError.create_pstmt(h) end
+    | -1 => return SQLError
     | -2 => return SQLInvalidHandle
     else
       recover val PonyDriverError("ODBCEnvFFI.prepare() got invalid return code: " + rv.string()) end
@@ -85,9 +85,9 @@ primitive \nodoc\ ODBCStmtFFI
     var rv: I16 =  @SQLExecDirect[I16](NullablePointer[ODBCHandleStmt tag](h), query.cstring(), query.size().i32())
     match rv
     | 0 => return SQLSuccess
-    | 1 => return recover val SQLSuccessWithInfo.create_pstmt(h) end
+    | 1 => return SQLSuccessWithInfo
     | 2 => return SQLStillExecuting
-    | -1 => return recover val SQLError.create_pstmt(h) end
+    | -1 => return SQLError
     | -2 => return SQLInvalidHandle
     | 99 => return SQLNeedData
     | 100 => return SQLNoData
@@ -114,9 +114,9 @@ primitive \nodoc\ ODBCStmtFFI
     var rv: I16 = @SQLExecute(NullablePointer[ODBCHandleStmt tag](h))
     match rv
     | 0 => return SQLSuccess
-    | 1 => return recover val SQLSuccessWithInfo.create_pstmt(h) end
+    | 1 => return SQLSuccessWithInfo
     | 2 => return SQLStillExecuting
-    | -1 => return recover val SQLError.create_pstmt(h) end
+    | -1 => return SQLError
     | -2 => return SQLInvalidHandle
     | 99 => return SQLNeedData
     | 100 => return SQLNoData
@@ -140,9 +140,9 @@ primitive \nodoc\ ODBCStmtFFI
         i.nullable_ptr)
     match rv
     | 0 => return SQLSuccess
-    | 1 => return recover val SQLSuccessWithInfo.create_pstmt(h) end
+    | 1 => return SQLSuccessWithInfo
     | 2 => return SQLStillExecuting
-    | -1 => return recover val SQLError.create_pstmt(h) end
+    | -1 => return SQLError
     | -2 => return SQLInvalidHandle
     else
       recover val PonyDriverError("ODBCHandleStmt.describe_param() get invalid return code: " + rv.string()) end
@@ -170,9 +170,9 @@ primitive \nodoc\ ODBCStmtFFI
 
     match rv
     | 0 => return SQLSuccess
-    | 1 => return recover val SQLSuccessWithInfo.create_pstmt(h) end
+    | 1 => return SQLSuccessWithInfo
     | 2 => return SQLStillExecuting
-    | -1 => return recover val SQLError.create_pstmt(h) end
+    | -1 => return SQLError
     | -2 => return SQLInvalidHandle
     else
       recover val PonyDriverError("ODBCHandleStmt.bind_parameter_varchar() get invalid return code: " + rv.string()) end
@@ -200,9 +200,9 @@ primitive \nodoc\ ODBCStmtFFI
 
     match rv
     | 0 => return SQLSuccess
-    | 1 => return recover val SQLSuccessWithInfo.create_pstmt(h) end
+    | 1 => return SQLSuccessWithInfo
     | 2 => return SQLStillExecuting
-    | -1 => return recover val SQLError.create_pstmt(h) end
+    | -1 => return SQLError
     | -2 => return SQLInvalidHandle
     else
       recover val PonyDriverError("ODBCHandleStmt.bind_parameter_i32() get invalid return code: " + rv.string()) end
@@ -240,9 +240,9 @@ primitive \nodoc\ ODBCStmtFFI
 
     match rv
     | 0 => return SQLSuccess
-    | 1 => return recover val SQLSuccessWithInfo.create_pstmt(h) end
+    | 1 => return SQLSuccessWithInfo
     | 2 => return SQLStillExecuting
-    | -1 => return recover val SQLError.create_pstmt(h) end
+    | -1 => return SQLError
     | -2 => return SQLInvalidHandle
     else
       recover val PonyDriverError("ODBCHandleStmt.describe_column() get invalid return code: " + rv.string()) end
@@ -268,9 +268,9 @@ primitive \nodoc\ ODBCStmtFFI
 
     match rv
     | 0 => return SQLSuccess
-    | 1 => return recover val SQLSuccessWithInfo.create_pstmt(h) end
+    | 1 => return SQLSuccessWithInfo
     | 2 => return SQLStillExecuting
-    | -1 => return recover val SQLError.create_pstmt(h) end
+    | -1 => return SQLError
     | -2 => return SQLInvalidHandle
     else
       recover val PonyDriverError("ODBCHandleStmt.bind_column_varchar() get invalid return code: " + rv.string()) end
@@ -297,9 +297,9 @@ primitive \nodoc\ ODBCStmtFFI
 
     match rv
     | 0 => return SQLSuccess
-    | 1 => return recover val SQLSuccessWithInfo.create_pstmt(h) end
+    | 1 => return SQLSuccessWithInfo
     | 2 => return SQLStillExecuting
-    | -1 => return recover val SQLError.create_pstmt(h) end
+    | -1 => return SQLError
     | -2 => return SQLInvalidHandle
     else
       recover val PonyDriverError("ODBCHandleStmt.bind_column_i32() get invalid return code: " + rv.string()) end
@@ -345,9 +345,9 @@ primitive \nodoc\ ODBCStmtFFI
     var rv: I16 = @SQLGetTypeInfo(NullablePointer[ODBCHandleStmt tag](h), dt)
     match rv
     | 0 => return SQLSuccess
-    | 1 => return recover val SQLSuccessWithInfo.create_pstmt(h) end
+    | 1 => return SQLSuccessWithInfo
     | 2 => return SQLStillExecuting
-    | -1 => return recover val SQLError.create_pstmt(h) end
+    | -1 => return SQLError
     | -2 => return SQLInvalidHandle
     else
       recover val PonyDriverError("ODBCHandleStmt.get_type_info() get invalid return code: " + rv.string()) end
@@ -366,9 +366,9 @@ primitive \nodoc\ ODBCStmtFFI
     var rv: I16 = @SQLFetch(NullablePointer[ODBCHandleStmt tag](h))
     match rv
     | 0 => return SQLSuccess
-    | 1 => return recover val SQLSuccessWithInfo.create_pstmt(h) end
+    | 1 => return SQLSuccessWithInfo
     | 2 => return SQLStillExecuting
-    | -1 => return recover val SQLError.create_pstmt(h) end
+    | -1 => return SQLError
     | -2 => return SQLInvalidHandle
     | 99 => return SQLNeedData
     | 100 => return SQLNoData
@@ -380,9 +380,9 @@ primitive \nodoc\ ODBCStmtFFI
     var rv: I16 = @SQLRowCount[I16](NullablePointer[ODBCHandleStmt tag](h), colcnt)
     match rv
     | 0 => return SQLSuccess
-    | 1 => return recover val SQLSuccessWithInfo.create_pstmt(h) end
+    | 1 => return SQLSuccessWithInfo
     | 2 => return SQLStillExecuting
-    | -1 => return recover val SQLError.create_pstmt(h) end
+    | -1 => return SQLError
     | -2 => return SQLInvalidHandle
     | 99 => return SQLNeedData
     | 100 => return SQLNoData
@@ -394,9 +394,9 @@ primitive \nodoc\ ODBCStmtFFI
     var rv: I16 = @SQLCloseCursor(NullablePointer[ODBCHandleStmt tag](h))
     match rv
     | 0 => return SQLSuccess
-    | 1 => return recover val SQLSuccessWithInfo.create_pstmt(h) end
+    | 1 => return SQLSuccessWithInfo
     | 2 => return SQLStillExecuting
-    | -1 => return recover val SQLError.create_pstmt(h) end
+    | -1 => return SQLError
     | -2 => return SQLInvalidHandle
     | 100 => return SQLNoData
     end

--- a/pony-odbc/odbc_stmt_ffi.pony
+++ b/pony-odbc/odbc_stmt_ffi.pony
@@ -17,7 +17,7 @@ use "debug"
 struct \nodoc\ ODBCHandleStmt
 
 primitive \nodoc\ ODBCStmtFFI
-  fun alloc(h: ODBCHandleDbc tag): (_SQLReturn val, ODBCHandleStmt tag) =>
+  fun alloc(h: ODBCHandleDbc tag): (SQLReturn val, ODBCHandleStmt tag) =>
     var rv: ODBCHandleStmt tag = ODBCHandleStmt
     var rvv: I16 = @SQLAllocHandle(3, NullablePointer[ODBCHandleDbc tag](h), addressof rv)
     match rvv
@@ -29,7 +29,7 @@ primitive \nodoc\ ODBCStmtFFI
       (recover val PonyDriverError("ODBCStmtFFI.alloc() got invalid return code: " + rvv.string()) end, rv)
     end
 
-  fun get_data(h: ODBCHandleStmt tag, col: U16, v: CBoxedArray): _SQLReturn val =>
+  fun get_data(h: ODBCHandleStmt tag, col: U16, v: CBoxedArray): SQLReturn val =>
     var rv: I16 = @SQLGetData[I16](
       NullablePointer[ODBCHandleStmt tag](h),
       col,
@@ -49,7 +49,7 @@ primitive \nodoc\ ODBCStmtFFI
       recover val PonyDriverError("ODBCEnvFFI.fetch_scroll() got invalid return code: " + rv.string()) end
     end
 
-  fun fetch_scroll(h: ODBCHandleStmt tag, d: SqlFetchOrientation, offset: I64 = 0): _SQLReturn val =>
+  fun fetch_scroll(h: ODBCHandleStmt tag, d: SqlFetchOrientation, offset: I64 = 0): SQLReturn val =>
     """
     SQLFetchScroll fetches the specified rowset of data from the result set and returns data for all bound columns. Rowsets can be specified at an absolute or relative position or by bookmark.
     """
@@ -65,7 +65,7 @@ primitive \nodoc\ ODBCStmtFFI
       recover val PonyDriverError("ODBCEnvFFI.fetch_scroll() got invalid return code: " + rv.string()) end
     end
 
-  fun prepare(h: ODBCHandleStmt tag, str: String val): _SQLReturn val =>
+  fun prepare(h: ODBCHandleStmt tag, str: String val): SQLReturn val =>
     """
     Prepares the provided SQL Statement.
     """
@@ -81,7 +81,7 @@ primitive \nodoc\ ODBCStmtFFI
     end
 
 // use @SQLExecDirect[I16](StatementHandle: Pointer[None] tag, StatementText: Pointer[U8] tag, TextLength: I32)
-  fun exec_direct(h: ODBCHandleStmt tag, query: String val): _SQLReturn val =>
+  fun exec_direct(h: ODBCHandleStmt tag, query: String val): SQLReturn val =>
     var rv: I16 =  @SQLExecDirect[I16](NullablePointer[ODBCHandleStmt tag](h), query.cstring(), query.size().i32())
     match rv
     | 0 => return SQLSuccess
@@ -96,7 +96,7 @@ primitive \nodoc\ ODBCStmtFFI
 
 
 
-  fun execute(h: ODBCHandleStmt tag): _SQLReturn val =>
+  fun execute(h: ODBCHandleStmt tag): SQLReturn val =>
     """
     Executes the provided SQL statement.
     
@@ -123,7 +123,7 @@ primitive \nodoc\ ODBCStmtFFI
     end
     recover val PonyDriverError("ODBCHandleStmt.execute() get invalid return code: " + rv.string()) end
 /*
-  fun describe_param(h: ODBCHandleStmt tag, i: SQLDescribeParamOut): _SQLReturn val =>
+  fun describe_param(h: ODBCHandleStmt tag, i: SQLDescribeParamOut): SQLReturn val =>
     """
     Used to query the parameter provided in the prepared statement so
     the database driver can validate that the correct fields have been
@@ -149,7 +149,7 @@ primitive \nodoc\ ODBCStmtFFI
     end
 
     */
-  fun bind_parameter_varchar(h: ODBCHandleStmt tag, col: U16, v: CBoxedArray): _SQLReturn val => // FIXME Refactor time
+  fun bind_parameter_varchar(h: ODBCHandleStmt tag, col: U16, v: CBoxedArray): SQLReturn val => // FIXME Refactor time
     """
     Binds a varchar, or similar variable type to a parameter.
     """
@@ -179,7 +179,7 @@ primitive \nodoc\ ODBCStmtFFI
     end
 
 /*
-  fun bind_parameter_i32(h: ODBCHandleStmt tag, desc: SQLDescribeParamOut, v: CBoxedI32): _SQLReturn val => // FIXME Refactor time
+  fun bind_parameter_i32(h: ODBCHandleStmt tag, desc: SQLDescribeParamOut, v: CBoxedI32): SQLReturn val => // FIXME Refactor time
     """
     Binds a varchar, or similar variable type to a parameter.
     """
@@ -209,7 +209,7 @@ primitive \nodoc\ ODBCStmtFFI
     end
 */
 /*
-  fun describe_column(h: ODBCHandleStmt tag, fillme: SQLDescribeColOut, colname: String val): _SQLReturn val =>
+  fun describe_column(h: ODBCHandleStmt tag, fillme: SQLDescribeColOut, colname: String val): SQLReturn val =>
 /*
   SQLHSTMT       StatementHandle,
   SQLUSMALLINT   ColumnNumber,
@@ -248,7 +248,7 @@ primitive \nodoc\ ODBCStmtFFI
       recover val PonyDriverError("ODBCHandleStmt.describe_column() get invalid return code: " + rv.string()) end
     end
 */
-  fun bind_column_varchar(h: ODBCHandleStmt tag, col: U16, v: CBoxedArray): _SQLReturn val =>
+  fun bind_column_varchar(h: ODBCHandleStmt tag, col: U16, v: CBoxedArray): SQLReturn val =>
 /*SQLRETURN SQLBindCol(
       SQLHSTMT       StatementHandle,
       SQLUSMALLINT   ColumnNumber,
@@ -276,7 +276,7 @@ primitive \nodoc\ ODBCStmtFFI
       recover val PonyDriverError("ODBCHandleStmt.bind_column_varchar() get invalid return code: " + rv.string()) end
     end
 /*
-  fun bind_column_i32(h: ODBCHandleStmt tag, desc: SQLDescribeColOut, v: CBoxedI32): _SQLReturn val =>
+  fun bind_column_i32(h: ODBCHandleStmt tag, desc: SQLDescribeColOut, v: CBoxedI32): SQLReturn val =>
 /*SQLRETURN SQLBindCol(
       SQLHSTMT       StatementHandle,
       SQLUSMALLINT   ColumnNumber,
@@ -306,7 +306,7 @@ primitive \nodoc\ ODBCStmtFFI
     end
 */
     /*
-  fun bind_column_i32(h: ODBCHandleStmt tag, desc: SQLDescribeColOut, v: CBoxedI32): _SQLReturn val =>
+  fun bind_column_i32(h: ODBCHandleStmt tag, desc: SQLDescribeColOut, v: CBoxedI32): SQLReturn val =>
 
 /*SQLRETURN SQLBindCol(
       SQLHSTMT       StatementHandle,
@@ -341,7 +341,7 @@ primitive \nodoc\ ODBCStmtFFI
 
 
 
-  fun get_type_info(h: ODBCHandleStmt tag, dt: I16): _SQLReturn val =>
+  fun get_type_info(h: ODBCHandleStmt tag, dt: I16): SQLReturn val =>
     var rv: I16 = @SQLGetTypeInfo(NullablePointer[ODBCHandleStmt tag](h), dt)
     match rv
     | 0 => return SQLSuccess
@@ -354,7 +354,7 @@ primitive \nodoc\ ODBCStmtFFI
     end
 
 
-  fun fetch(h: ODBCHandleStmt tag): _SQLReturn val =>
+  fun fetch(h: ODBCHandleStmt tag): SQLReturn val =>
     """
     SQL_SUCCESS
     SQL_SUCCESS_WITH_INFO
@@ -376,7 +376,7 @@ primitive \nodoc\ ODBCStmtFFI
     recover val PonyDriverError("ODBCHandleStmt.fetch() get invalid return code: " + rv.string()) end
 
 //use @SQLNumResultCols[I16](StatementHandle: Pointer[None] tag, ColumnCount: CBoxedI16 tag)
-  fun result_count(h: ODBCHandleStmt tag, colcnt: CBoxedI64): _SQLReturn val =>
+  fun result_count(h: ODBCHandleStmt tag, colcnt: CBoxedI64): SQLReturn val =>
     var rv: I16 = @SQLRowCount[I16](NullablePointer[ODBCHandleStmt tag](h), colcnt)
     match rv
     | 0 => return SQLSuccess
@@ -390,7 +390,7 @@ primitive \nodoc\ ODBCStmtFFI
     recover val PonyDriverError("ODBCHandleStmt.result_count() get invalid return code: " + rv.string()) end
 
     // use @SQLCloseCursor[I16](StatementHandle: Pointer[None] tag)
-  fun close_cursor(h: ODBCHandleStmt tag): _SQLReturn val =>
+  fun close_cursor(h: ODBCHandleStmt tag): SQLReturn val =>
     var rv: I16 = @SQLCloseCursor(NullablePointer[ODBCHandleStmt tag](h))
     match rv
     | 0 => return SQLSuccess

--- a/pony-odbc/sql_big_int.pony
+++ b/pony-odbc/sql_big_int.pony
@@ -5,15 +5,15 @@ class SQLBigInteger is SQLType
   The internal class which represents an Integer (I64)
   """
   var _v: CBoxedArray = CBoxedArray
-  var _err: _SQLReturn val = SQLSuccess
+  var _err: SQLReturn val = SQLSuccess
 
   new create() => _v.alloc(22)
 
   fun \nodoc\ ref get_boxed_array(): CBoxedArray => _v
   fun \nodoc\ ref set_boxed_array(v': CBoxedArray) => _v = v'
 
-  fun \nodoc\ ref get_err(): _SQLReturn val => _err
-  fun \nodoc\ ref set_err(err': _SQLReturn val) => _err = err'
+  fun \nodoc\ ref get_err(): SQLReturn val => _err
+  fun \nodoc\ ref set_err(err': SQLReturn val) => _err = err'
 
   fun ref write(i64: I64): Bool =>
     """

--- a/pony-odbc/sql_error.pony
+++ b/pony-odbc/sql_error.pony
@@ -1,7 +1,9 @@
 use "debug"
 use "collections"
 
-class \nodoc\ SQLError
+primitive \nodoc\ SQLError
+  fun string(): String val => "SQLError"
+  /*
   var _location: SourceLoc val = __loc
   var _records: Array[(I16, SQLDiagFrame)] = Array[(I16, SQLDiagFrame)]
 
@@ -88,3 +90,4 @@ class \nodoc\ SQLError
       rv.push(f.rec_tuple())
     end
     consume rv
+              */

--- a/pony-odbc/sql_float.pony
+++ b/pony-odbc/sql_float.pony
@@ -5,15 +5,15 @@ class SQLFloat is SQLType
   The internal class which represents an Integer (F32)
   """
   var _v: CBoxedArray = CBoxedArray
-  var _err: _SQLReturn val = SQLSuccess
+  var _err: SQLReturn val = SQLSuccess
 
   new create() => _v.alloc(20)
 
   fun \nodoc\ ref get_boxed_array(): CBoxedArray => _v
   fun \nodoc\ ref set_boxed_array(v': CBoxedArray) => _v = v'
 
-  fun \nodoc\ ref get_err(): _SQLReturn val => _err
-  fun \nodoc\ ref set_err(err': _SQLReturn val) => _err = err'
+  fun \nodoc\ ref get_err(): SQLReturn val => _err
+  fun \nodoc\ ref set_err(err': SQLReturn val) => _err = err'
 
   fun ref write(f32: F32): Bool =>
     """

--- a/pony-odbc/sql_integer.pony
+++ b/pony-odbc/sql_integer.pony
@@ -5,15 +5,15 @@ class SQLInteger is SQLType
   The internal class which represents an Integer (I32)
   """
   var _v: CBoxedArray = CBoxedArray
-  var _err: _SQLReturn val = SQLSuccess
+  var _err: SQLReturn val = SQLSuccess
 
   new create() => _v.alloc(15)
 
   fun \nodoc\ ref get_boxed_array(): CBoxedArray => _v
   fun \nodoc\ ref set_boxed_array(v': CBoxedArray) => _v = v'
 
-  fun \nodoc\ ref get_err(): _SQLReturn val => _err
-  fun \nodoc\ ref set_err(err': _SQLReturn val) => _err = err'
+  fun \nodoc\ ref get_err(): SQLReturn val => _err
+  fun \nodoc\ ref set_err(err': SQLReturn val) => _err = err'
 
   fun ref write(i32: I32): Bool =>
     """

--- a/pony-odbc/sql_real.pony
+++ b/pony-odbc/sql_real.pony
@@ -5,15 +5,15 @@ class SQLReal is SQLType
   The internal class which represents an Integer (F32)
   """
   var _v: CBoxedArray = CBoxedArray
-  var _err: _SQLReturn val = SQLSuccess
+  var _err: SQLReturn val = SQLSuccess
 
   new create() => _v.alloc(30)
 
   fun \nodoc\ ref get_boxed_array(): CBoxedArray => _v
   fun \nodoc\ ref set_boxed_array(v': CBoxedArray) => _v = v'
 
-  fun \nodoc\ ref get_err(): _SQLReturn val => _err
-  fun \nodoc\ ref set_err(err': _SQLReturn val) => _err = err'
+  fun \nodoc\ ref get_err(): SQLReturn val => _err
+  fun \nodoc\ ref set_err(err': SQLReturn val) => _err = err'
 
   fun ref write(f64: F64): Bool =>
     """

--- a/pony-odbc/sql_return.pony
+++ b/pony-odbc/sql_return.pony
@@ -1,5 +1,5 @@
 
-type _SQLReturn is (SQLSuccess | SQLSuccessWithInfo | SQLStillExecuting | SQLError | SQLInvalidHandle | SQLNeedData | PonyDriverError | SQLNoData)
+type SQLReturn is (SQLSuccess | SQLSuccessWithInfo | SQLStillExecuting | SQLError | SQLInvalidHandle | SQLNeedData | PonyDriverError | SQLNoData)
   """
   # Return Codes ODBC
 Each function in ODBC returns a code, known as its *return code,* which indicates the overall success or failure of the function. Program logic is generally based on return codes.

--- a/pony-odbc/sql_small_int.pony
+++ b/pony-odbc/sql_small_int.pony
@@ -5,15 +5,15 @@ class SQLSmallInteger is SQLType
   The internal class which represents an Integer (I16)
   """
   var _v: CBoxedArray = CBoxedArray
-  var _err: _SQLReturn val = SQLSuccess
+  var _err: SQLReturn val = SQLSuccess
 
   new create() => _v.alloc(8)
 
   fun \nodoc\ ref get_boxed_array(): CBoxedArray => _v
   fun \nodoc\ ref set_boxed_array(v': CBoxedArray) => _v = v'
 
-  fun \nodoc\ ref get_err(): _SQLReturn val => _err
-  fun \nodoc\ ref set_err(err': _SQLReturn val) => _err = err'
+  fun \nodoc\ ref get_err(): SQLReturn val => _err
+  fun \nodoc\ ref set_err(err': SQLReturn val) => _err = err'
 
   fun ref write(i16: I16): Bool =>
     """

--- a/pony-odbc/sql_success_with_info.pony
+++ b/pony-odbc/sql_success_with_info.pony
@@ -1,7 +1,9 @@
 use "debug"
 use "collections"
 
-class \nodoc\ SQLSuccessWithInfo
+primitive \nodoc\ SQLSuccessWithInfo
+  fun string(): String val => "SQLSuccessWithInfo"
+  /*
   var _locations: SourceLoc val = __loc
   var _records: Array[(I16, SQLDiagFrame)] = Array[(I16, SQLDiagFrame)]
 
@@ -79,4 +81,4 @@ class \nodoc\ SQLSuccessWithInfo
       rv.push(f.rec_tuple())
     end
     consume rv
-
+*/

--- a/pony-odbc/sql_type.pony
+++ b/pony-odbc/sql_type.pony
@@ -30,8 +30,8 @@ trait SQLType
   fun \nodoc\ ref get_boxed_array(): CBoxedArray
   fun \nodoc\ ref set_boxed_array(v: CBoxedArray)
 
-  fun \nodoc\ ref get_err(): _SQLReturn val
-  fun \nodoc\ ref set_err(err: _SQLReturn val)
+  fun \nodoc\ ref get_err(): SQLReturn val
+  fun \nodoc\ ref set_err(err: SQLReturn val)
 
   fun \nodoc\ ref alloc(size: USize): Bool =>
     get_boxed_array().alloc(size)
@@ -78,7 +78,7 @@ trait SQLType
     if (not get_boxed_array().write_array(arr)) then return false end
     true
 
-  fun \nodoc\ ref bind_parameter(h: ODBCHandleStmt tag, col: U16): _SQLReturn val =>
+  fun \nodoc\ ref bind_parameter(h: ODBCHandleStmt tag, col: U16): SQLReturn val =>
     if (not _bind_parameter(h, col)) then
       return get_err()
     end
@@ -95,7 +95,7 @@ trait SQLType
       false
     end
 
-  fun \nodoc\ ref realloc_column(h: ODBCHandleStmt tag, size: USize, col: U16): _SQLReturn val =>
+  fun \nodoc\ ref realloc_column(h: ODBCHandleStmt tag, size: USize, col: U16): SQLReturn val =>
     """
     Reallocates the buffer to be populated by the database when data
     is fetched and rebinds the new buffer to the column.
@@ -103,7 +103,7 @@ trait SQLType
     set_boxed_array(CBoxedArray .> alloc(size))
     bind_column(h, col)
 
-  fun \nodoc\ ref bind_column(h: ODBCHandleStmt tag, col: U16): _SQLReturn val =>
+  fun \nodoc\ ref bind_column(h: ODBCHandleStmt tag, col: U16): SQLReturn val =>
     if (not _bind_column(h, col)) then
       return get_err()
     end

--- a/pony-odbc/sql_varbinary.pony
+++ b/pony-odbc/sql_varbinary.pony
@@ -5,7 +5,7 @@ class SQLVarbinary is SQLType
   The internal class which represents a binary blob
   """
   var _v: CBoxedArray = CBoxedArray
-  var _err: _SQLReturn val = SQLSuccess
+  var _err: SQLReturn val = SQLSuccess
 
   new create(size: USize) => _v.alloc(size)
     """
@@ -15,8 +15,8 @@ class SQLVarbinary is SQLType
   fun \nodoc\ ref get_boxed_array(): CBoxedArray => _v
   fun \nodoc\ ref set_boxed_array(v': CBoxedArray) => _v = v'
 
-  fun \nodoc\ ref get_err(): _SQLReturn val => _err
-  fun \nodoc\ ref set_err(err': _SQLReturn val) => _err = err'
+  fun \nodoc\ ref get_err(): SQLReturn val => _err
+  fun \nodoc\ ref set_err(err': SQLReturn val) => _err = err'
 
   fun ref write(str: Array[U8] val): Bool =>
     """

--- a/pony-odbc/sql_varchar.pony
+++ b/pony-odbc/sql_varchar.pony
@@ -5,7 +5,7 @@ class SQLVarchar is SQLType
   The internal class which represents a CHAR, VARCHAR, or TEXT
   """
   var _v: CBoxedArray = CBoxedArray
-  var _err: _SQLReturn val = SQLSuccess
+  var _err: SQLReturn val = SQLSuccess
 
   new create(size: USize) => _v.alloc(size)
     """
@@ -15,8 +15,8 @@ class SQLVarchar is SQLType
   fun \nodoc\ ref get_boxed_array(): CBoxedArray => _v
   fun \nodoc\ ref set_boxed_array(v': CBoxedArray) => _v = v'
 
-  fun \nodoc\ ref get_err(): _SQLReturn val => _err
-  fun \nodoc\ ref set_err(err': _SQLReturn val) => _err = err'
+  fun \nodoc\ ref get_err(): SQLReturn val => _err
+  fun \nodoc\ ref set_err(err': SQLReturn val) => _err = err'
 
   fun ref write(str: String val): Bool =>
     """


### PR DESCRIPTION
Since we are moving away from having SQLError and SQLSuccessWithInfo automatically call the GetDiagRec type functions, they are now being used as pure return values.