### PR TITLE
Defaults simple API to Bool ? everywhere

### DIFF
--- a/.release-notes/40.md
+++ b/.release-notes/40.md
@@ -1,0 +1,5 @@
+## Defaults for simple API calls to Bool ?
+
+Changes the default return values for the API calls to Bool ?. Typically they all either return true or error, but in some cases like fetch(), they indicate something else like "no more data in the result dataset".
+
+Adds ODBCDbc.get\_info() to query data types.

--- a/pony-odbc/ffi/f.pony
+++ b/pony-odbc/ffi/f.pony
@@ -658,8 +658,8 @@ The following table lists ODBC functions, grouped by type of task, and includes 
     [FundamentalType(short int) size=16]
     [PointerType size=64]->[FundamentalType(short int) size=16]
 */
-  fun pSQLGetInfo(pConnectionHandle: Pointer[None] tag, pInfoType: U16, pInfoValue: Pointer[None] tag, pBufferLength: I16, pStringLength: CBoxedI16): I16 =>
-    @SQLGetInfo(pConnectionHandle, pInfoType, pInfoValue, pBufferLength, pStringLength)
+  fun pSQLGetInfo(pConnectionHandle: ODBCHandleDbc tag, pInfoType: U16, pInfoValue: Pointer[U8] tag, pBufferLength: I16, pStringLength: CBoxedI16): I16 =>
+    @SQLGetInfo(NullablePointer[ODBCHandleDbc tag](pConnectionHandle), pInfoType, pInfoValue, pBufferLength, pStringLength)
 
 
 /*

--- a/pony-odbc/odbc_dbc.pony
+++ b/pony-odbc/odbc_dbc.pony
@@ -61,7 +61,7 @@ class ODBCDbc is SqlState
   fun sqlstates(): Array[(String val, String val)] val =>
     _from_dbc(dbc)
 
-  fun ref get_autocommit(): Bool ? =>
+  fun ref get_autocommit(sl: SourceLoc = __loc): Bool ? =>
     var value: CBoxedI32 = CBoxedI32
     _err = ODBCFFI.resolve(ODBCFFI.pSQLGetConnectAttr_i32(dbc, _SqlAttrAutoCommit(), value, 4, CBoxedI32))
     _check_valid()?
@@ -69,7 +69,7 @@ class ODBCDbc is SqlState
     if (value.value == _SqlAutoCommitOff()) then return false end
     error
 
-  fun ref set_autocommit(setting: Bool) ? =>
+  fun ref set_autocommit(setting: Bool, sl: SourceLoc = __loc): Bool ? =>
     if (setting) then
       _err = ODBCFFI.resolve(
         ODBCFFI.pSQLSetConnectAttr_i32(dbc, _SqlAttrAutoCommit(), _SqlAutoCommitOn(), 9))
@@ -93,6 +93,20 @@ class ODBCDbc is SqlState
     """
     _call_location = sl
     _err = ODBCFFI.resolve(ODBCFFI.pSQLEndTran_dbc(2, dbc, 1))
+    _check_valid()?
+
+  fun ref get_info(infotype: U16, buf: SQLType, sl: SourceLoc = __loc): Bool ? =>
+    """
+    SQLGetInfo returns general information about the driver and data source associated with a connection.
+    """
+    _call_location = sl
+    _err = ODBCFFI.resolve(
+      ODBCFFI.pSQLGetInfo(dbc,
+                         infotype,
+                         buf.get_boxed_array().ptr,
+                         buf.get_boxed_array().alloc_size.i16(),
+                         CBoxedI16)
+    )
     _check_valid()?
 
   fun ref connect(dsn: String val, sl: SourceLoc val = __loc): Bool ? =>

--- a/pony-odbc/odbc_env.pony
+++ b/pony-odbc/odbc_env.pony
@@ -69,7 +69,7 @@ class ODBCEnv is SqlState
       end
     end
 
-  fun \nodoc\ ref get_attr(a: _SqlEnvAttr, v: CBoxedI32) ? =>
+  fun \nodoc\ ref get_attr(a: _SqlEnvAttr, v: CBoxedI32): Bool ? =>
     """
     This is a primitive getter function used to retrieve i32 attributes
     from the ODBC Handle. 

--- a/pony-odbc/odbc_stmt.pony
+++ b/pony-odbc/odbc_stmt.pony
@@ -153,7 +153,7 @@ class ODBCStmt is SqlState
   fun sqlstates(): Array[(String val, String val)] val =>
     _from_stmt(_sth)
 
-  fun ref prepare(str: String val, sl: SourceLoc val = __loc) ? =>
+  fun ref prepare(str: String val, sl: SourceLoc val = __loc): Bool ? =>
     """
     Used to 'prepare' a SQL statement.
 
@@ -166,7 +166,7 @@ class ODBCStmt is SqlState
     _err = ODBCFFI.resolve(ODBCFFI.pSQLPrepare(_sth, str, str.size().i32()))
     _check_valid()?
 
-  fun ref bind_parameter(i: SQLType, sl: SourceLoc val = __loc) ? =>
+  fun ref bind_parameter(i: SQLType, sl: SourceLoc val = __loc): Bool ? =>
     """
     Used to bind a parameter to a prepared query.
 
@@ -185,7 +185,7 @@ class ODBCStmt is SqlState
     _err = i.get_err()
     _check_valid()?
 
-  fun ref bind_column(i: SQLType, sl: SourceLoc val = __loc) ? =>
+  fun ref bind_column(i: SQLType, sl: SourceLoc val = __loc): Bool ? =>
     """
     Used to bind a column in a result-set for the prepared query.
 
@@ -207,7 +207,7 @@ class ODBCStmt is SqlState
     _err = i.get_err()
     _check_valid()?
 
-  fun ref execute(sl: SourceLoc val = __loc) ? =>
+  fun ref execute(sl: SourceLoc val = __loc): Bool ? =>
     """
     Before executing your prepared command you should populate your
     parameters with the necessary data.
@@ -219,7 +219,7 @@ class ODBCStmt is SqlState
     _err = ODBCFFI.resolve(ODBCFFI.pSQLExecute(_sth))
     _check_valid()?
 
-  fun ref direct_exec(statement: String val, sl: SourceLoc val = __loc) ? =>
+  fun ref direct_exec(statement: String val, sl: SourceLoc val = __loc): Bool ? =>
     """
     Directly executes the provided statement.
 
@@ -246,7 +246,26 @@ class ODBCStmt is SqlState
     _check_valid()?
     rv.value
 
-  fun ref columns(catalog: String val = "", schema: String val = "", table: String val = "", column: String val = "", sl: SourceLoc = __loc) ? =>
+  fun ref num_result_cols(rv: CBoxedI16, sl: SourceLoc val = __loc): Bool ? =>
+    """
+    *Warning*: The ODBC standard does not mandate this function's correctness.
+
+    Any response from the ODBC driver other than a non-warning success will
+    result in a thrown error.
+    """
+    _call_location = sl
+    _err = ODBCFFI.resolve(
+      ODBCFFI.pSQLNumResultCols(_sth, rv))
+    _check_valid()?
+
+  fun ref get_type_info(sqltype: I16 = 0 ,sl: SourceLoc = __loc): Bool ? => // SQL_ALL_TYPES
+    _call_location = sl
+    _err = ODBCFFI.resolve(
+      ODBCFFI.pSQLGetTypeInfo(_sth, sqltype)
+    )
+    _check_valid()?
+
+  fun ref columns(catalog: String val = "", schema: String val = "", table: String val = "", column: String val = "", sl: SourceLoc = __loc): Bool ? =>
     _call_location = sl
     _err = ODBCFFI.resolve(
       ODBCFFI.pSQLColumns(
@@ -263,7 +282,7 @@ class ODBCStmt is SqlState
       )
     _check_valid()?
 
-  fun ref get_data(column: U16, sqltype: SQLType)? =>
+  fun ref get_data(column: U16, sqltype: SQLType): Bool ? =>
     ODBCFFI.resolve(
       ODBCFFI.pSQLGetData(
         _sth,
@@ -313,7 +332,7 @@ class ODBCStmt is SqlState
     end
 
 
-  fun ref finish(sl: SourceLoc val = __loc) ? =>
+  fun ref finish(sl: SourceLoc val = __loc): Bool ? =>
     """
     Closes the cursor on a result-set.
 

--- a/pony-odbc/tests/_test.pony
+++ b/pony-odbc/tests/_test.pony
@@ -38,3 +38,11 @@ actor \nodoc\ Main is TestList
     test(_MariaDBBasic("mariadb"))
     test(_MariaDBBasic("psqlred"))
     test(_MariaDBBasic("sqlitedb3"))
+
+    test(_MariaDBInfo("mariadb"))
+    test(_MariaDBInfo("psqlred"))
+    test(_MariaDBInfo("sqlitedb3"))
+
+    test(_MariaDBTran("mariadb"))
+    test(_MariaDBTran("psqlred"))
+    test(_MariaDBTran("sqlitedb3"))

--- a/pony-odbc/tests/info.pony
+++ b/pony-odbc/tests/info.pony
@@ -1,0 +1,51 @@
+
+
+use "debug"
+use "pony_test"
+use "collections"
+use ".."
+use "../ffi"
+
+class \nodoc\ iso _MariaDBInfo is UnitTest
+  var dsn: String val
+
+  new create(dsn': String val) =>
+    dsn = dsn'
+
+  fun name(): String val => "_MariaDBInfo(" + dsn + ")"
+
+  fun apply(h: TestHelper) ? =>
+    var env: ODBCEnv = ODBCEnv
+    var dbh: ODBCDbc = env.dbc()?
+    dbh.connect(dsn)?
+
+    try get_type_info(h, dbh)? else h.fail("Failed in get_type_info") end
+    try sql_get_type_info(h, dbh)? else h.fail("Failed in sql_get_type_info") end
+
+    try
+      var dbc: ODBCDbc = env.dbc()?
+    else
+      try
+      Debug.out(env.sqlstates()(0)?._1 + ": " + env.sqlstates()(0)?._2)
+      end
+    end
+
+  fun get_type_info(h: TestHelper, dbh: ODBCDbc) ? =>
+    var sth: ODBCStmt = dbh.stmt()?
+
+    sth.get_type_info()?
+    var result_cols: CBoxedI16 = CBoxedI16
+    h.assert_true(sth.num_result_cols(result_cols)?)
+    h.assert_eq[I16](19, result_cols.value)
+    h.assert_true(sth.finish()?)
+
+  fun sql_get_type_info(h: TestHelper, dbh: ODBCDbc) ? =>
+    var buf: SQLVarchar = SQLVarchar(512)
+    dbh.get_info(6, buf)?  // SQL_DRIVER_NAME
+    var nm: String = buf.string()
+    buf.reset()
+    dbh.get_info(77, buf)? // SQL_DRIVER_ODBC_VER
+    var vr: String = buf.string()
+    Debug.out("[" + dsn + "]: " + nm + " → " + vr)
+
+    // Need to distinguish for actual integers vs stringified integers.

--- a/pony-odbc/tests/tran.pony
+++ b/pony-odbc/tests/tran.pony
@@ -1,0 +1,73 @@
+use "debug"
+use "pony_test"
+use "collections"
+use ".."
+use "../ffi"
+
+class \nodoc\ iso _MariaDBTran is UnitTest
+  var dsn: String val
+
+  new create(dsn': String val) =>
+    dsn = dsn'
+
+  fun name(): String val => "_MariaDBTran(" + dsn + ")"
+
+  fun apply(h: TestHelper) ? =>
+    var env: ODBCEnv = ODBCEnv
+    var dbh: ODBCDbc = env.dbc()?
+    dbh.set_autocommit(false)?
+    dbh.connect(dsn)?
+
+    try my_transaction(h, dbh)? else h.fail("Failed in my_transaction") end
+
+    try
+      var dbc: ODBCDbc = env.dbc()?
+    else
+      try
+      Debug.out(env.sqlstates()(0)?._1 + ": " + env.sqlstates()(0)?._2)
+      end
+    end
+
+  fun my_transaction(h: TestHelper, dbh: ODBCDbc) ? =>
+    h.assert_false(dbh.get_autocommit()?)
+    var sth: ODBCStmt = dbh.stmt()?
+
+    sth.strict = false
+    sth.direct_exec("DROP TABLE IF EXISTS t1")?
+    sth.strict = true
+    dbh.commit()?
+
+    sth.direct_exec("CREATE TABLE t1 (col1 INT, col2 VARCHAR(30))")?
+    sth.direct_exec("INSERT INTO t1 VALUES (10,'venu')")?
+    dbh.commit()?
+
+    sth.direct_exec("INSERT INTO t1 VALUES (20,'mysql')")?
+    dbh.rollback()?
+
+    sth.direct_exec("DELETE FROM t1 WHERE col1 = 10")?
+    dbh.rollback()?
+    sth.finish()?
+
+    sth.direct_exec("SELECT * FROM t1")?
+    h.assert_true(sth.fetch()?)
+    sth.finish()?
+
+    sth.direct_exec("INSERT INTO t1 VALUES (30,'test'),(40,'transaction')")?
+    dbh.commit()?
+
+    sth.direct_exec("DELETE FROM t1 WHERE col1 = 30")?
+    dbh.commit()?
+
+    sth.direct_exec("SELECT * FROM t1 WHERE col1 = 30")?
+    h.assert_false(sth.fetch()?)
+    sth.finish()?
+
+    sth.direct_exec("DELETE FROM t1 WHERE col1 = 40")?
+    dbh.commit()?
+
+    sth.direct_exec("SELECT * FROM t1 WHERE col1 = 40")?
+    h.assert_false(sth.fetch()?)
+    sth.finish()?
+
+    sth.direct_exec("DROP TABLE t1")?
+    sth.finish()?


### PR DESCRIPTION
* Changes the default return values for the API calls to Bool ?.  Typically they all either return true or error, but in some cases like fetch(), they indicate something else like "no more data in the result dataset.

* Added ODBCDbc.get_info() to query data types.