### PR TITLE
Fixed ODBCStmt reuse bug

### DIFF
--- a/.release-notes/45.md
+++ b/.release-notes/45.md
@@ -1,0 +1,5 @@
+## Fixed ODBCStmt reuse bug
+
+When we created a new query on an existing STMT handle the ODBC driver would clear all the parameter and column buffers, but not the local cache.
+
+This change clears the private \_parameters and \_columns when .finish()? is executed.

--- a/pony-odbc/odbc_stmt.pony
+++ b/pony-odbc/odbc_stmt.pony
@@ -380,6 +380,8 @@ class ODBCStmt is SqlState
     Closes the result-set using SQLFreeStmt.
     """
     _call_location = sl
+    _parameters.clear()
+    _columns.clear()
     _err = ODBCFFI.resolve(ODBCFFI.pSQLFreeStmt(_sth, 0))
     _check_valid()?
 


### PR DESCRIPTION
When we created a new query on an existing STMT handle the ODBC driver would clear all the parameter and column buffers, but not the local cache.

This change clears the private \_parameters and \_columns when .finish()? is executed.