### PR TITLE
Fix buffer handling bugs and improve robustness

### DIFF
--- a/pony-odbc/odbc_dbc.pony
+++ b/pony-odbc/odbc_dbc.pony
@@ -109,13 +109,15 @@ class ODBCDbc is SqlState
     source associated with a connection.
     """
     _call_location = sl
+    var string_length: CBoxedI16 = CBoxedI16
     _err = ODBCFFI.resolve(
       ODBCFFI.pSQLGetInfo_varchar(dbc,
                          infotype,
                          buf.get_boxed_array().ptr,
                          buf.get_boxed_array().alloc_size.i16(),
-                         CBoxedI16)
+                         string_length)
     )
+    buf.get_boxed_array().written_size.value = string_length.value.i64()
     _check_valid()?
 
   fun ref connect(dsn: String val, sl: SourceLoc val = __loc): Bool ? =>

--- a/pony-odbc/odbc_stmt.pony
+++ b/pony-odbc/odbc_stmt.pony
@@ -388,7 +388,8 @@ class ODBCStmt is SqlState
   fun \nodoc\ ref _check_and_expand_column_buffers(sl: SourceLoc val = __loc) ? =>
     _call_location = sl
     for (colindex, vc) in _columns.pairs() do
-      if (vc.get_boxed_array().written_size.value.usize() > vc.get_boxed_array().alloc_size) then
+      let ws = vc.get_boxed_array().written_size.value
+      if (ws > 0) and (ws.usize() > vc.get_boxed_array().alloc_size) then
         _err = vc.realloc_column(_sth, vc.get_boxed_array().written_size.value.usize() + 10, colindex.u16() + 1)
         _check_valid()?
 

--- a/pony-odbc/sql_big_int.pony
+++ b/pony-odbc/sql_big_int.pony
@@ -38,8 +38,4 @@ class SQLBigInteger is SQLType
     that specific ODBC driver, this is something that must be
     verified.
     """
-    if (get_boxed_array().is_null()) then
-      error
-    else
-      _v.string().i64()?
-    end
+    _v.string()?.i64()?

--- a/pony-odbc/sql_float.pony
+++ b/pony-odbc/sql_float.pony
@@ -38,8 +38,4 @@ class SQLFloat is SQLType
     that specific ODBC driver, this is something that must be
     verified.
     """
-    if (get_boxed_array().is_null()) then
-      error
-    else
-      _v.string().f32()?
-    end
+    _v.string()?.f32()?

--- a/pony-odbc/sql_integer.pony
+++ b/pony-odbc/sql_integer.pony
@@ -38,8 +38,4 @@ class SQLInteger is SQLType
     that specific ODBC driver, this is something that must be
     verified.
     """
-    if (get_boxed_array().is_null()) then
-      error
-    else
-      _v.string().i32()?
-    end
+    _v.string()?.i32()?

--- a/pony-odbc/sql_real.pony
+++ b/pony-odbc/sql_real.pony
@@ -38,8 +38,4 @@ class SQLReal is SQLType
     that specific ODBC driver, this is something that must be
     verified.
     """
-    if (get_boxed_array().is_null()) then
-      error
-    else
-      _v.string().f64()?
-    end
+    _v.string()?.f64()?

--- a/pony-odbc/sql_small_int.pony
+++ b/pony-odbc/sql_small_int.pony
@@ -38,8 +38,4 @@ class SQLSmallInteger is SQLType
     that specific ODBC driver, this is something that must be
     verified.
     """
-    if (get_boxed_array().is_null()) then
-      error
-    else
-      _v.string().i16()?
-    end
+    _v.string()?.i16()?

--- a/pony-odbc/sql_type.pony
+++ b/pony-odbc/sql_type.pony
@@ -47,17 +47,17 @@ trait SQLType
     """
     get_boxed_array().reset()
 
-  fun \nodoc\ ref string(): String iso^ =>
+  fun \nodoc\ ref string(): String iso^ ? =>
     """
     Returns the written contents of the buffer as a string
     """
-    get_boxed_array().string()
+    get_boxed_array().string()?
 
-  fun \nodoc\ ref array(): Array[U8] iso^ =>
+  fun \nodoc\ ref array(): Array[U8] iso^ ? =>
     """
     Returns the written contents of the buffer as an array.
     """
-    get_boxed_array().array()
+    get_boxed_array().array()?
 
   fun \nodoc\ ref _write(str: String val): Bool =>
     """
@@ -67,9 +67,7 @@ trait SQLType
     (We can't reallocate, just in case this buffer is already bound
     to a query already)
     """
-    if (not get_boxed_array().write(str)) then return false end
-    if (str != get_boxed_array().string()) then return false end
-    true
+    get_boxed_array().write(str)
 
   fun \nodoc\ ref _write_array(arr: Array[U8] val): Bool =>
     """

--- a/pony-odbc/sql_varbinary.pony
+++ b/pony-odbc/sql_varbinary.pony
@@ -33,12 +33,8 @@ class SQLVarbinary is SQLType
 
   fun ref read(): Array[U8] iso^ ? =>
     """
-    Read the value of the buffer into a String iso^. This is an iso^
+    Read the value of the buffer into an Array[U8] iso^. This is an iso^
     copy of the data so the buffer can remain in place and reused
     without rebinding.
     """
-    if (get_boxed_array().is_null()) then
-      error
-    else
-      _v.array()
-    end
+    _v.array()?

--- a/pony-odbc/sql_varchar.pony
+++ b/pony-odbc/sql_varchar.pony
@@ -37,8 +37,4 @@ class SQLVarchar is SQLType
     copy of the data so the buffer can remain in place and reused
     without rebinding.
     """
-    if (get_boxed_array().is_null()) then
-      error
-    else
-      _v.string()
-    end
+    _v.string()?

--- a/pony-odbc/tests/info.pony
+++ b/pony-odbc/tests/info.pony
@@ -42,10 +42,10 @@ class \nodoc\ iso _MariaDBInfo is UnitTest
   fun sql_get_type_info(h: TestHelper, dbh: ODBCDbc) ? =>
     var buf: SQLVarchar = SQLVarchar(512)
     dbh.get_info_varchar(6, buf)?  // SQL_DRIVER_NAME
-    var nm: String = buf.string()
+    var nm: String = buf.string()?
     buf.reset()
     dbh.get_info_varchar(77, buf)? // SQL_DRIVER_ODBC_VER
-    var vr: String = buf.string()
+    var vr: String = buf.string()?
     Debug.out("[" + dsn + "]: " + nm + " → " + vr)
 
     // Need to distinguish for actual integers vs stringified integers.


### PR DESCRIPTION
- Fix string() to use written_size instead of null-terminator scanning
- Fix array() to check for NULL state and properly initialize output array
- Make string() and array() partial to throw on NULL reads
- Remove redundant write verification in _write() for better performance
- Fix column expansion comparison to handle SQL_NULL_DATA (-1) values
- Add documentation for CBoxedArray NULL state semantics
- Fix get_info_varchar() to properly set written_size after ODBC call